### PR TITLE
MORE-339: Add roles to the StudyManagerAPI

### DIFF
--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/StudyTransformer.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/StudyTransformer.java
@@ -4,11 +4,8 @@ import io.redlink.more.studymanager.api.v1.model.StatusChangeDTO;
 import io.redlink.more.studymanager.api.v1.model.StudyDTO;
 import io.redlink.more.studymanager.api.v1.model.StudyStatusDTO;
 import io.redlink.more.studymanager.model.Study;
-import org.threeten.bp.ZoneOffset;
-
 import java.sql.Date;
 import java.time.OffsetDateTime;
-import java.time.OffsetTime;
 
 public class StudyTransformer {
 

--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/UserInfoTransformer.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/UserInfoTransformer.java
@@ -3,7 +3,7 @@
  */
 package io.redlink.more.studymanager.model.transformer;
 
-import io.redlink.more.studymanager.api.v1.model.PlatformPermissionDTO;
+import io.redlink.more.studymanager.api.v1.model.PlatformRoleDTO;
 import io.redlink.more.studymanager.api.v1.model.UserInfoDTO;
 import io.redlink.more.studymanager.model.MoreUser;
 import java.util.Objects;
@@ -19,20 +19,20 @@ public final class UserInfoTransformer {
                 .name(user.fullName())
                 .email(user.email())
                 .institution(user.institution())
-                .permissions(toPlatformPermissions(user.roles()));
+                .roles(toPlatformRoles(user.roles()));
     }
 
-    public static Set<PlatformPermissionDTO> toPlatformPermissions(Set<MoreUser.Role> roles) {
+    public static Set<PlatformRoleDTO> toPlatformRoles(Set<MoreUser.Role> roles) {
         return roles.stream()
-                .map(UserInfoTransformer::toPlatformPermission)
+                .map(UserInfoTransformer::toPlatformRole)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toUnmodifiableSet());
     }
 
-    public static PlatformPermissionDTO toPlatformPermission(MoreUser.Role role) {
+    public static PlatformRoleDTO toPlatformRole(MoreUser.Role role) {
         return switch (role) {
-            case STUDY_VIEWER -> PlatformPermissionDTO.READ_STUDIES;
-            case STUDY_CREATOR -> PlatformPermissionDTO.CREATE_STUDIES;
+            case STUDY_VIEWER -> PlatformRoleDTO.VIEWER;
+            case STUDY_CREATOR -> PlatformRoleDTO.OPERATOR;
             default -> null;
         };
     }

--- a/studymanager/src/main/resources/openapi/StudyManagerAPI.yaml
+++ b/studymanager/src/main/resources/openapi/StudyManagerAPI.yaml
@@ -790,6 +790,14 @@ components:
           type: string
           format: date-time
           readOnly: true
+        userRoles:
+          type: array
+          description: the roles the _current user_ has within _this_ study.
+          items:
+            $ref: '#/components/schemas/StudyRole'
+          uniqueItems: true
+          readOnly: true
+          minItems: 1
 
     StatusChange:
       type: object
@@ -987,20 +995,41 @@ components:
           type: string
           format: email
           readOnly: true
-        permissions:
+        roles:
           type: array
           items:
-            $ref: '#/components/schemas/PlatformPermission'
+            $ref: '#/components/schemas/PlatformRole'
           uniqueItems: true
           readOnly: true
       readOnly: true
 
-    PlatformPermission:
+    PlatformRole:
+      description: |
+        We differentiate between the following roles within a study:
+        * `MORE_ADMIN` (_System Administrator_, _Platform Administrator_): Rights to manage users, emergency functions, **no rights to see data or manipulate studies**.
+        * `MORE_OPERATOR`: Can create/initiate a new Study
+        * `MORE_VIEWER`: Can access existing studies (based on assigned study-level roles)
       type: string
       enum:
-        - READ_STUDIES
-        - CREATE_STUDIES
+        - MORE_ADMIN
+        - MORE_OPERATOR
+        - MORE_VIEWER
+      externalDocs:
+        url: https://more-platform.atlassian.net/browse/MORE-213
 
+    StudyRole:
+      description: |
+        We differentiate between the following roles within a study:
+        * `STUDY_ADMIN` (_Study Administrator_): **All** rights to create and manage studies, configure components and assign participants, invite and manage operators and viewers and see study data.
+        * `STUDY_OPERATOR` (_Study Operator_): Rights to manage studies, configure components and assign participants, **no rights to see data**.
+        * `STUDY_VIEWER` (_Study Viewer_): Rights to see study data only.
+      type: string
+      enum:
+        - STUDY_ADMIN
+        - STUDY_OPERATOR
+        - STUDY_VIEWER
+      externalDocs:
+        url: https://more-platform.atlassian.net/browse/MORE-213
 
   parameters:
     StudyId:

--- a/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/UserControllerTest.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/UserControllerTest.java
@@ -45,9 +45,9 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.name").value(moreUser.fullName()))
                 .andExpect(jsonPath("$.email").value(moreUser.email()))
                 .andExpect(jsonPath("$.institution").value(moreUser.institution()))
-                .andExpect(jsonPath("$.permissions").value(
+                .andExpect(jsonPath("$.roles").value(
                         Matchers.contains(
-                                UserInfoTransformer.toPlatformPermission(MoreUser.Role.STUDY_CREATOR).getValue())
+                                UserInfoTransformer.toPlatformRole(MoreUser.Role.STUDY_CREATOR).getValue())
                         ))
         ;
     }


### PR DESCRIPTION
### Summary

We differentiate between the following roles within a study:
* "Global Roles":
  * `MORE_ADMIN` (_System Administrator_, _Platform Administrator_): Rights to manage users, emergency functions, **no rights to see data or manipulate studies**.
  * `MORE_OPERATOR`: Can **create**/initiate a new Study
  * `MORE_VIEWER`: Can access **existing studies** (based on assigned study-level roles)
* "Study Role":
  * `STUDY_ADMIN` (_Study Administrator_): **All** rights to create and manage studies, configure components and assign participants, invite and manage operators and viewers and see study data.
  * `STUDY_OPERATOR` (_Study Operator_): Rights to manage studies, configure components and assign participants, **no rights to see data**.
  * `STUDY_VIEWER` (_Study Viewer_): Rights to see study data only.