### PR TITLE
MORE-455: Add the Study-State in the dedicated Auth-View for the Gateway

### DIFF
--- a/studymanager/src/main/resources/db/migration/V1_4_0__study_state_in_gateway_view.sql
+++ b/studymanager/src/main/resources/db/migration/V1_4_0__study_state_in_gateway_view.sql
@@ -1,0 +1,9 @@
+-- Update gateway-view
+CREATE OR REPLACE VIEW auth_routing_info (api_id, api_secret, study_id, participant_id, study_group_id, study_is_active) AS
+SELECT api_credentials.*, pt.study_group_id, s.status = 'active'
+FROM api_credentials
+         INNER JOIN participants pt
+                    ON (api_credentials.study_id = pt.study_id and api_credentials.participant_id = pt.participant_id)
+         INNER JOIN studies s
+                    ON (api_credentials.study_id = s.study_id)
+;


### PR DESCRIPTION
Not the full state, but an indicator whether the study is `active`.