### PR TITLE
MORE-556 add lime survey to docker-compose.yaml with postgres db

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -87,12 +87,10 @@ services:
 
   lime-db:
     image: postgres:14-alpine
-    ports:
-      - "5433:5432"
     volumes:
       - type: volume
         source: lime-db-data
-        target: /var/lib/postgresql/limesurvey-data
+        target: /var/lib/postgresql/data
     environment:
       POSTGRES_USER: limesurvey
       POSTGRES_DB: limesurvey


### PR DESCRIPTION
Set up of the docker image for lime survey as seen here: https://github.com/martialblog/docker-limesurvey/blob/master/docker-compose.example.yml 

The docker image for limesurvey only works with postgres 14 or lower.
Admin login at http://localhost:8081/admin with user=admin and password=admin