### PR TITLE
Collect common DTO<-->Model transformations in one place.

### DIFF
--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/ActionTransformer.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/ActionTransformer.java
@@ -5,9 +5,11 @@ import io.redlink.more.studymanager.core.properties.ActionProperties;
 import io.redlink.more.studymanager.model.Action;
 import io.redlink.more.studymanager.utils.MapperUtils;
 
-import java.time.ZoneOffset;
+public final class ActionTransformer {
 
-public class ActionTransformer {
+    private ActionTransformer() {
+    }
+
     public static Action fromActionDTO_V1(ActionDTO dto) {
         return new Action()
                 .setActionId(dto.getActionId())
@@ -20,8 +22,8 @@ public class ActionTransformer {
                 .actionId(action.getActionId())
                 .type(action.getType())
                 .properties(action.getProperties())
-                .created(action.getCreated().atOffset(ZoneOffset.UTC))
-                .modified(action.getModified().atOffset(ZoneOffset.UTC));
+                .created(Transformers.toOffsetDateTime(action.getCreated()))
+                .modified(Transformers.toOffsetDateTime(action.getModified()));
     }
 
 }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/EventTransformer.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/EventTransformer.java
@@ -7,52 +7,54 @@ import io.redlink.more.studymanager.api.v1.model.WeekdayDTO;
 import io.redlink.more.studymanager.model.Event;
 import io.redlink.more.studymanager.model.RecurrenceRule;
 
-import java.time.ZoneOffset;
+public final class EventTransformer {
 
-public class EventTransformer {
+    private EventTransformer() {
+    }
+
     public static Event fromEventDTO_V1(EventDTO dto) {
-        if(dto != null)
+        if (dto != null)
             return new Event()
-                .setDateStart(dto.getDtstart() != null ? dto.getDtstart().toInstant() : null)
-                .setDateEnd(dto.getDtend() != null ? dto.getDtend().toInstant() : null)
-                .setRRule(fromRecurrenceRuleDTO(dto.getRrule()));
+                    .setDateStart(Transformers.toInstant(dto.getDtstart()))
+                    .setDateEnd(Transformers.toInstant(dto.getDtend()))
+                    .setRRule(fromRecurrenceRuleDTO(dto.getRrule()));
         else return null;
     }
 
     public static EventDTO toEventDTO_V1(Event event) {
-        if(event != null)
+        if (event != null)
             return new EventDTO()
-                .dtstart(event.getDateStart() != null ? event.getDateStart().atOffset(ZoneOffset.UTC) : null)
-                .dtend(event.getDateEnd() != null ? event.getDateEnd().atOffset(ZoneOffset.UTC) : null)
-                .rrule(toRecurrenceRuleDTO(event.getRRule()));
+                    .dtstart(Transformers.toOffsetDateTime(event.getDateStart()))
+                    .dtend(Transformers.toOffsetDateTime(event.getDateEnd()))
+                    .rrule(toRecurrenceRuleDTO(event.getRRule()));
         else return null;
     }
 
     private static RecurrenceRule fromRecurrenceRuleDTO(RecurrenceRuleDTO dto) {
-        if(dto != null)
+        if (dto != null)
             return new RecurrenceRule()
-                .setFreq(dto.getFreq().getValue())
-                .setInterval(dto.getInterval())
-                .setCount(dto.getCount())
-                .setUntil(dto.getUntil() != null ? dto.getUntil().toInstant() : null)
-                .setByDay(dto.getByday() != null ? dto.getByday().stream().map(WeekdayDTO::getValue).toList() : null)
-                .setByMonth(dto.getBymonth())
-                .setByMonthDay(dto.getBymonthday())
-                .setBySetPos(dto.getBysetpos());
+                    .setFreq(dto.getFreq().getValue())
+                    .setInterval(dto.getInterval())
+                    .setCount(dto.getCount())
+                    .setUntil(Transformers.toInstant(dto.getUntil()))
+                    .setByDay(dto.getByday() != null ? dto.getByday().stream().map(WeekdayDTO::getValue).toList() : null)
+                    .setByMonth(dto.getBymonth())
+                    .setByMonthDay(dto.getBymonthday())
+                    .setBySetPos(dto.getBysetpos());
         else return null;
     }
 
     private static RecurrenceRuleDTO toRecurrenceRuleDTO(RecurrenceRule recurrenceRule) {
-        if(recurrenceRule != null)
+        if (recurrenceRule != null)
             return new RecurrenceRuleDTO()
-                .freq(recurrenceRule.getFreq() != null ? FrequencyDTO.fromValue(recurrenceRule.getFreq()) : null)
-                .interval(recurrenceRule.getInterval())
-                .count(recurrenceRule.getCount())
-                .until(recurrenceRule.getUntil() != null ? recurrenceRule.getUntil().atOffset(ZoneOffset.UTC) : null)
-                .byday(recurrenceRule.getByDay() != null ? recurrenceRule.getByDay().stream().map(WeekdayDTO::fromValue).toList() : null)
-                .bymonth(recurrenceRule.getByMonth())
-                .bymonthday(recurrenceRule.getByMonthDay())
-                .bysetpos(recurrenceRule.getBySetPos());
+                    .freq(recurrenceRule.getFreq() != null ? FrequencyDTO.fromValue(recurrenceRule.getFreq()) : null)
+                    .interval(recurrenceRule.getInterval())
+                    .count(recurrenceRule.getCount())
+                    .until(Transformers.toOffsetDateTime(recurrenceRule.getUntil()))
+                    .byday(recurrenceRule.getByDay() != null ? recurrenceRule.getByDay().stream().map(WeekdayDTO::fromValue).toList() : null)
+                    .bymonth(recurrenceRule.getByMonth())
+                    .bymonthday(recurrenceRule.getByMonthDay())
+                    .bysetpos(recurrenceRule.getBySetPos());
         else return null;
     }
 }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/InterventionTransformer.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/InterventionTransformer.java
@@ -1,11 +1,12 @@
 package io.redlink.more.studymanager.model.transformer;
 
-import io.redlink.more.studymanager.api.v1.model.EventDTO;
 import io.redlink.more.studymanager.api.v1.model.InterventionDTO;
 import io.redlink.more.studymanager.model.Intervention;
-import java.time.ZoneOffset;
 
-public class InterventionTransformer {
+public final class InterventionTransformer {
+
+    private InterventionTransformer() {
+    }
 
     public static Intervention fromInterventionDTO_V1(InterventionDTO dto) {
         return new Intervention()
@@ -25,8 +26,8 @@ public class InterventionTransformer {
                 .purpose(intervention.getPurpose())
                 .studyGroupId(intervention.getStudyGroupId())
                 .schedule(EventTransformer.toEventDTO_V1(intervention.getSchedule()))
-                .created(intervention.getCreated().atOffset(ZoneOffset.UTC))
-                .modified(intervention.getModified().atOffset(ZoneOffset.UTC));
+                .created(Transformers.toOffsetDateTime(intervention.getCreated()))
+                .modified(Transformers.toOffsetDateTime(intervention.getModified()));
     }
 
 }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/ObservationTransformer.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/ObservationTransformer.java
@@ -1,14 +1,15 @@
 package io.redlink.more.studymanager.model.transformer;
 
-import io.redlink.more.studymanager.api.v1.model.EventDTO;
 import io.redlink.more.studymanager.api.v1.model.ObservationDTO;
 import io.redlink.more.studymanager.core.properties.ObservationProperties;
 import io.redlink.more.studymanager.model.Observation;
 import io.redlink.more.studymanager.utils.MapperUtils;
 
-import java.time.OffsetDateTime;
+public final class ObservationTransformer {
 
-public class ObservationTransformer {
+    private ObservationTransformer() {
+    }
+
     public static Observation fromObservationDTO_V1(ObservationDTO dto) {
         return new Observation()
                 .setStudyId(dto.getStudyId())
@@ -33,8 +34,8 @@ public class ObservationTransformer {
                 .studyGroupId(observation.getStudyGroupId())
                 .properties(observation.getProperties())
                 .schedule(EventTransformer.toEventDTO_V1(observation.getSchedule()))
-                .created(observation.getCreated().toLocalDateTime().atOffset(OffsetDateTime.now().getOffset()))
-                .modified(observation.getModified().toLocalDateTime().atOffset(OffsetDateTime.now().getOffset()));
+                .created(Transformers.toOffsetDateTime(observation.getCreated()))
+                .modified(Transformers.toOffsetDateTime(observation.getModified()));
     }
 
 }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/ParticipantTransformer.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/ParticipantTransformer.java
@@ -4,8 +4,6 @@ import io.redlink.more.studymanager.api.v1.model.ParticipantDTO;
 import io.redlink.more.studymanager.api.v1.model.ParticipantStatusDTO;
 import io.redlink.more.studymanager.model.Participant;
 
-import java.time.OffsetDateTime;
-
 public class ParticipantTransformer {
 
     private ParticipantTransformer() {
@@ -28,8 +26,8 @@ public class ParticipantTransformer {
                 .studyGroupId(participant.getStudyGroupId())
                 .registrationToken(participant.getRegistrationToken())
                 .status(ParticipantStatusDTO.fromValue(participant.getStatus().getValue()))
-                .modified(participant.getModified().toLocalDateTime().atOffset(OffsetDateTime.now().getOffset()))
-                .created(participant.getCreated().toLocalDateTime().atOffset(OffsetDateTime.now().getOffset()));
+                .modified(Transformers.toOffsetDateTime(participant.getModified()))
+                .created(Transformers.toOffsetDateTime(participant.getCreated()));
     }
 
 }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/StudyDataTransformer.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/StudyDataTransformer.java
@@ -3,8 +3,6 @@ package io.redlink.more.studymanager.model.transformer;
 import io.redlink.more.studymanager.api.v1.model.ParticipationDataDTO;
 import io.redlink.more.studymanager.model.ParticipationData;
 
-import java.time.OffsetDateTime;
-
 public class StudyDataTransformer {
 
     private StudyDataTransformer(){}
@@ -15,6 +13,6 @@ public class StudyDataTransformer {
                 .participantId(participationData.participantId())
                 .studyGroupId(participationData.studyGroupId())
                 .dataReceived(participationData.dataReceived())
-                .lastDataReceived(participationData.lastDataReceived() != null ? participationData.lastDataReceived().atOffset(OffsetDateTime.now().getOffset()) : null);
+                .lastDataReceived(Transformers.toOffsetDateTime(participationData.lastDataReceived()));
     }
 }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/StudyGroupTransformer.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/StudyGroupTransformer.java
@@ -3,9 +3,10 @@ package io.redlink.more.studymanager.model.transformer;
 import io.redlink.more.studymanager.api.v1.model.StudyGroupDTO;
 import io.redlink.more.studymanager.model.StudyGroup;
 
-import java.time.OffsetDateTime;
+public final class StudyGroupTransformer {
 
-public class StudyGroupTransformer {
+    private StudyGroupTransformer() {
+    }
 
     public static StudyGroup fromStudyGroupDTO_V1(StudyGroupDTO studyGroupDTO) {
         return new StudyGroup()
@@ -21,7 +22,7 @@ public class StudyGroupTransformer {
                 .studyGroupId(studyGroup.getStudyGroupId())
                 .title(studyGroup.getTitle())
                 .purpose(studyGroup.getPurpose())
-                .created(studyGroup.getCreated().toLocalDateTime().atOffset(OffsetDateTime.now().getOffset()))
-                .modified(studyGroup.getModified().toLocalDateTime().atOffset(OffsetDateTime.now().getOffset()));
+                .created(Transformers.toOffsetDateTime(studyGroup.getCreated()))
+                .modified(Transformers.toOffsetDateTime(studyGroup.getModified()));
     }
 }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/StudyTransformer.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/StudyTransformer.java
@@ -5,7 +5,6 @@ import io.redlink.more.studymanager.api.v1.model.StudyDTO;
 import io.redlink.more.studymanager.api.v1.model.StudyStatusDTO;
 import io.redlink.more.studymanager.model.Study;
 import java.sql.Date;
-import java.time.OffsetDateTime;
 
 public class StudyTransformer {
 
@@ -20,8 +19,8 @@ public class StudyTransformer {
                 .setPurpose(studyDTO.getPurpose())
                 .setParticipantInfo(studyDTO.getParticipantInfo())
                 .setConsentInfo(studyDTO.getConsentInfo())
-                .setPlannedStartDate(studyDTO.getPlannedStart() != null ? Date.valueOf(studyDTO.getPlannedStart()): null)
-                .setPlannedEndDate(studyDTO.getPlannedEnd() != null ? Date.valueOf(studyDTO.getPlannedEnd()): null);
+                .setPlannedStartDate(Transformers.toSqlDate(studyDTO.getPlannedStart()))
+                .setPlannedEndDate(Transformers.toSqlDate(studyDTO.getPlannedEnd()));
     }
 
     public static StudyDTO toStudyDTO_V1(Study study) {
@@ -32,12 +31,12 @@ public class StudyTransformer {
                 .participantInfo(study.getParticipantInfo())
                 .consentInfo(study.getConsentInfo())
                 .status(StudyStatusDTO.fromValue(study.getStudyState().getValue()))
-                .start(study.getStartDate() != null ? study.getStartDate().toLocalDate() : null)
-                .end(study.getEndDate() != null ? study.getEndDate().toLocalDate() : null)
-                .plannedStart(study.getPlannedStartDate() != null ? study.getPlannedStartDate().toLocalDate() : null)
-                .plannedEnd(study.getPlannedEndDate() != null ? study.getPlannedEndDate().toLocalDate(): null)
-                .created(study.getCreated().toLocalDateTime().atOffset(OffsetDateTime.now().getOffset()))
-                .modified(study.getModified().toLocalDateTime().atOffset(OffsetDateTime.now().getOffset()))
+                .start(Transformers.toLocalDate(study.getStartDate()))
+                .end(Transformers.toLocalDate(study.getEndDate()))
+                .plannedStart(Transformers.toLocalDate(study.getPlannedStartDate()))
+                .plannedEnd(Transformers.toLocalDate(study.getPlannedEndDate()))
+                .created(Transformers.toOffsetDateTime(study.getCreated()))
+                .modified(Transformers.toOffsetDateTime(study.getModified()))
                 .userRoles(RoleTransformer.toStudyRolesDTO(study.getUserRoles()))
                 ;
     }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/Transformers.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/Transformers.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2023 Redlink GmbH.
+ */
+package io.redlink.more.studymanager.model.transformer;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.function.Function;
+
+/**
+ * Common basic transformers.
+ */
+public final class Transformers {
+
+    private static final ZoneId HOME = ZoneId.of("Europe/Vienna");
+
+    private Transformers() {
+    }
+
+    /**
+     * @deprecated Use {@link LocalDate} or {@link Instant} (as appropriate) on the business-logic/model layer.
+     */
+    @Deprecated(forRemoval = true)
+    public static LocalDate toLocalDate(Date date) {
+        return transform(date, d ->
+                d.toInstant()
+                        .atZone(HOME)
+                        .toLocalDate()
+        );
+    }
+
+    /**
+     * @deprecated Use {@link LocalDate} on the business-logic/model layer.
+     */
+    @Deprecated(forRemoval = true)
+    public static LocalDate toLocalDate(java.sql.Date date) {
+        return transform(date, java.sql.Date::toLocalDate);
+    }
+
+    /**
+     * This is a placeholder to help with the model-migration to {@link LocalDate}.
+     */
+    public static LocalDate toLocalDate(final LocalDate localDate) {
+        return localDate;
+    }
+
+    /**
+     * @deprecated Use {@link Instant} or {@link LocalDate} (as appropriate) on the business-logic/model layer.
+     */
+    @Deprecated(forRemoval = true)
+    public static OffsetDateTime toOffsetDateTime(Date date) {
+        return transform(date, d ->
+                d.toInstant()
+                        .atZone(HOME)
+                        .toOffsetDateTime()
+        );
+    }
+
+    /**
+     * @deprecated Use {@link LocalDate} on the business-logic/model layer.
+     */
+    @Deprecated(forRemoval = true)
+    public static java.sql.Date toSqlDate(LocalDate localDate) {
+        return transform(localDate, java.sql.Date::valueOf);
+    }
+
+    public static OffsetDateTime toOffsetDateTime(Instant instant) {
+        return transform(instant, i -> i.atZone(HOME).toOffsetDateTime());
+    }
+
+    /**
+     * @deprecated Use {@link Instant} on the business-logic/model layer.
+     */
+    @Deprecated(forRemoval = true)
+    public static OffsetDateTime toOffsetDateTime(Timestamp timestamp) {
+        return transform(timestamp, t -> toOffsetDateTime(t.toInstant()));
+    }
+
+    public static Instant toInstant(OffsetDateTime offsetDateTime) {
+        return transform(offsetDateTime, OffsetDateTime::toInstant);
+    }
+
+    /**
+     * Performs a null-safe conversion of {@code t} using the {@code transformer}.
+     * @param t the value to transform.
+     * @param transformer the transformation-function. the argument passed to this function will never be {@code null}.
+     * @return the result of {@code transformer.apply(t)} or {@code null}
+     */
+    public static <T, R> R transform(final T t, final Function<T, R> transformer) {
+        if (t == null) {
+            return null;
+        }
+        return transformer.apply(t);
+    }
+}

--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/TriggerTransformer.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/TriggerTransformer.java
@@ -5,9 +5,11 @@ import io.redlink.more.studymanager.core.properties.TriggerProperties;
 import io.redlink.more.studymanager.model.Trigger;
 import io.redlink.more.studymanager.utils.MapperUtils;
 
-import java.time.ZoneOffset;
+public final class TriggerTransformer {
 
-public class TriggerTransformer {
+    private TriggerTransformer() {
+    }
+
     public static Trigger fromTriggerDTO_V1(TriggerDTO dto) {
         return new Trigger()
                 .setType(dto.getType())
@@ -18,7 +20,7 @@ public class TriggerTransformer {
         return new TriggerDTO()
                 .type(trigger.getType())
                 .properties(trigger.getProperties())
-                .created(trigger.getCreated().atOffset(ZoneOffset.UTC))
-                .modified(trigger.getModified().atOffset(ZoneOffset.UTC));
+                .created(Transformers.toOffsetDateTime(trigger.getCreated()))
+                .modified(Transformers.toOffsetDateTime(trigger.getModified()));
     }
 }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/UserInfoTransformer.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/UserInfoTransformer.java
@@ -17,7 +17,6 @@ import io.redlink.more.studymanager.model.StudyRole;
 import io.redlink.more.studymanager.model.StudyUserRoles;
 import io.redlink.more.studymanager.model.User;
 import java.net.URI;
-import java.time.ZoneOffset;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -77,7 +76,7 @@ public final class UserInfoTransformer {
         return new CollaboratorRoleDetailsDTO()
                 .role(RoleTransformer.toStudyRoleDTO(role.role()))
                 .assignedBy(toUserInfoDTO(role.creator()))
-                .assignedAt(role.created().atOffset(ZoneOffset.UTC))
+                .assignedAt(Transformers.toOffsetDateTime(role.created()))
                 ;
     }
 


### PR DESCRIPTION
I found many different ways how we convert common object like Dates between internal model and DTO.
To have an aligned representation on the API such transformations should happen at a central place, so I've collected those in the  `Transformers`-Util.
