### PR TITLE
MORE-1008: install maven-modules with resolved version-tags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,8 @@
         <docker.namespace>more-project</docker.namespace>
 
         <start-class>io.redlink.more.studymanager.Application</start-class>
+
+        <maven.install.skip>false</maven.install.skip>
     </properties>
 
     <scm>
@@ -51,6 +53,32 @@
     </scm>
 
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.5.0</version>
+                <configuration>
+                    <outputDirectory>${build.directory}</outputDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten-clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -74,7 +102,7 @@
                     <artifactId>maven-install-plugin</artifactId>
                     <version>3.1.1</version>
                     <configuration>
-                        <skip>true</skip>
+                        <skip>${maven.install.skip}</skip>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -427,4 +455,18 @@
         </dependencies>
     </dependencyManagement>
 
+    <profiles>
+        <profile>
+            <id>quick</id>
+            <activation>
+                <property>
+                    <name>quick</name>
+                </property>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+                <skipITs>true</skipITs>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/studymanager/pom.xml
+++ b/studymanager/pom.xml
@@ -212,11 +212,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>flatten-maven-plugin</artifactId>
-                <version>1.5.0</version>
-            </plugin>
-            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
@@ -303,21 +298,5 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>quick</id>
-            <activation>
-                <property>
-                    <name>quick</name>
-                </property>
-            </activation>
-            <properties>
-                <skipTests>true</skipTests>
-                <skipITs>true</skipITs>
-            </properties>
-
-        </profile>
-    </profiles>
 
 </project>


### PR DESCRIPTION
To `install` maven modules to the local registry, run

```shell
./mvnw clean install -Dmaven.install.skip=false
```
