### PR TITLE
Changing the LimeSurvey ID for running Studies is now forbidden

### DIFF
--- a/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyRequestService.java
+++ b/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyRequestService.java
@@ -138,15 +138,22 @@ public class LimeSurveyRequestService {
                 );
             LOGGER.info("sent {} participants to lime", participantIds.size());
 
-            List<ParticipantData> data = mapper.readValue(client.send(request, HttpResponse.BodyHandlers.ofString()).body(),
-                            LimeSurveyParticipantResponse.class)
-                    .result();
+            String rsp = client.send(request, HttpResponse.BodyHandlers.ofString()).body();
+
+            if(rsp.contains("Error: Invalid survey ID")) {
+                throw new RuntimeException("Invalid survey ID: " + surveyId);
+            }
+
+            List<ParticipantData> data = mapper.readValue(
+                    rsp,
+                    LimeSurveyParticipantResponse.class
+            ).result();
 
             releaseSessionKey(sessionKey);
 
             LOGGER.info("result: {}", data.stream().map(ParticipantData::toString).collect(Collectors.joining()));
             return data;
-        }catch(IOException | InterruptedException e){
+        } catch( IOException | InterruptedException e){
             LOGGER.error("Error creating participants for survey {}", surveyId);
             throw new RuntimeException(e);
         }

--- a/studymanager-observation/src/test/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyObservationTest.java
+++ b/studymanager-observation/src/test/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyObservationTest.java
@@ -1,0 +1,37 @@
+package io.redlink.more.studymanager.component.observation.lime;
+
+import io.redlink.more.studymanager.core.properties.ObservationProperties;
+import io.redlink.more.studymanager.core.sdk.MoreObservationSDK;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LimeSurveyObservationTest {
+    @Test
+    public void testLimeSurveyIdValidation() {
+        MoreObservationSDK sdk = mock(MoreObservationSDK.class);
+        ObservationProperties properties = mock(ObservationProperties.class);
+
+        when(sdk.getValue(anyString(), any()))
+                .thenReturn(Optional.empty(), Optional.of("equals"), Optional.of("other"));
+        when(properties.getString(anyString())).thenReturn("valid", "equals", "different");
+
+        LimeSurveyObservation o = new LimeSurveyObservation(sdk, properties, null);
+        Assertions.assertEquals("valid", o.checkAndGetSurveyId());
+        Assertions.assertEquals("equals", o.checkAndGetSurveyId());
+        boolean expectedError = false;
+        try {
+            o.checkAndGetSurveyId();
+        } catch (RuntimeException e) {
+            expectedError = true;
+        }
+
+        Assertions.assertTrue(expectedError);
+    }
+}

--- a/studymanager/src/main/java/io/redlink/more/studymanager/exception/BadRequestException.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/exception/BadRequestException.java
@@ -14,8 +14,13 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(code = HttpStatus.BAD_REQUEST)
 public class BadRequestException extends RuntimeException {
+
     public BadRequestException(String cause) {
         super(cause);
+    }
+
+    public BadRequestException(String cause, Throwable throwable) {
+        super(String.format("%s: %s", cause, throwable.getMessage()), throwable);
     }
 
     public BadRequestException(Throwable cause) {

--- a/studymanager/src/main/java/io/redlink/more/studymanager/service/StudyService.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/service/StudyService.java
@@ -127,7 +127,7 @@ public class StudyService {
                 //ROLLBACK
                 studyRepository.setStateById(studyId, oldState);
                 studyRepository.getById(studyId).ifPresent(this::alignWithStudyState);
-                throw new BadRequestException("Study cannot be initialized");
+                throw new BadRequestException("Study cannot be initialized",e);
             }
         });
     }


### PR DESCRIPTION
One a Study has been started, reassigning the LimeSurvey-ID within an Observation is prohibited:

This is to ensure the integrity of the answers. If you need to change the connection to LimeSurvey, create a new Observation and disable/remove the old one.

Closes MORE-Platform/more-app-multiplatform/issues/227