### PR TITLE
Bugfix #245: Fix DB-Migration Script for NvPairs

### DIFF
--- a/studymanager/src/main/java/io/redlink/more/studymanager/repository/NameValuePairRepository.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/repository/NameValuePairRepository.java
@@ -19,9 +19,15 @@ import java.util.Optional;
 @Component
 public class NameValuePairRepository {
 
-    private static final String UPSERT = "INSERT INTO nvpairs(issuer,name,value) VALUES (?,?,?) ON CONFLICT(issuer,name) DO UPDATE SET value = EXCLUDED.value";
-    private static final String READ = "SELECT value FROM nvpairs WHERE issuer = ? AND name = ? LIMIT 1";
-    private static final String REMOVE = "DELETE FROM nvpairs WHERE issuer = ? AND name = ?";
+    private static final String UPSERT_O = "INSERT INTO nvpairs_observations(study_id, observation_id, name, value) VALUES (?,?,?,?) ON CONFLICT(study_id, observation_id, name) DO UPDATE SET value = EXCLUDED.value";
+    private static final String UPSERT_T = "INSERT INTO nvpairs_triggers(study_id, intervention_id, name, value) VALUES (?,?,?,?) ON CONFLICT(study_id, intervention_id, name) DO UPDATE SET value = EXCLUDED.value";
+    private static final String UPSERT_A = "INSERT INTO nvpairs_actions(study_id, intervention_id, action_id, name, value) VALUES (?,?,?,?,?) ON CONFLICT(study_id, intervention_id, action_id, name) DO UPDATE SET value = EXCLUDED.value";
+    private static final String READ_O = "SELECT value FROM nvpairs_observations WHERE study_id = ? AND observation_id = ? AND name = ? LIMIT 1";
+    private static final String READ_T = "SELECT value FROM nvpairs_triggers WHERE study_id = ? AND intervention_id = ? AND name = ? LIMIT 1";
+    private static final String READ_A = "SELECT value FROM nvpairs_actions WHERE study_id = ? AND intervention_id = ? AND action_id = ? AND name = ? LIMIT 1";
+    private static final String REMOVE_O = "DELETE FROM nvpairs_observations WHERE study_id = ? AND observation_id = ? AND name = ?";
+    private static final String REMOVE_T = "DELETE FROM nvpairs_triggers WHERE study_id = ? AND intervention_id = ? AND name = ?";
+    private static final String REMOVE_A = "DELETE FROM nvpairs_actions WHERE study_id = ? AND intervention_id = ? AND action_id = ? AND name = ?";
 
     private final JdbcTemplate template;
 
@@ -29,25 +35,68 @@ public class NameValuePairRepository {
         this.template = template;
     }
 
-    public <T extends Serializable> void setValue(String issuer, String name, T value) {
-        this.template.update(UPSERT, issuer, name, SerializationUtils.serialize(value));
+    public <T extends Serializable> void setObservationValue(Long studyId, int observationId, String name, T value) {
+        this.template.update(UPSERT_O, studyId, observationId, name, SerializationUtils.serialize(value));
     }
 
-    public <T extends Serializable> Optional<T> getValue(String issuer, String name, Class<T> tClass) {
+    public <T extends Serializable> void setTriggerValue(Long studyId, int interventionId, String name, T value) {
+        this.template.update(UPSERT_T, studyId, interventionId, name, SerializationUtils.serialize(value));
+    }
+
+    public <T extends Serializable> void setActionValue(Long studyId, int interventionId, int actionId, String name, T value) {
+        this.template.update(UPSERT_A, studyId, interventionId, actionId, name, SerializationUtils.serialize(value));
+    }
+
+    public <T extends Serializable> Optional<T> getObservationValue(Long studyId, int observationId, String name, Class<T> tClass) {
         try {
-            return Optional.ofNullable(this.template.queryForObject(READ,
+            return Optional.ofNullable(this.template.queryForObject(READ_O,
                     (rs, rowNum) -> tClass.cast(SerializationUtils.deserialize(rs.getBytes("value"))),
-                    issuer, name));
+                    studyId, observationId, name));
         } catch (EmptyResultDataAccessException e) {
             return Optional.empty();
         }
     }
 
-    public void removeValue(String issuer, String name) {
-        this.template.update(REMOVE, issuer, name);
+    public <T extends Serializable> Optional<T> getTriggerValue(Long studyId, int interventionId, String name, Class<T> tClass) {
+        try {
+            return Optional.ofNullable(this.template.queryForObject(READ_T,
+                    (rs, rowNum) -> tClass.cast(SerializationUtils.deserialize(rs.getBytes("value"))),
+                    studyId, interventionId, name));
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
+    }
+
+    public <T extends Serializable> Optional<T> getActionValue(Long studyId, int interventionId, int actionId, String name, Class<T> tClass) {
+        try {
+            return Optional.ofNullable(this.template.queryForObject(READ_A,
+                    (rs, rowNum) -> tClass.cast(SerializationUtils.deserialize(rs.getBytes("value"))),
+                    studyId, interventionId, actionId, name));
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
+    }
+
+    public void removeObservationValue(Long studyId, int observationId, String name) {
+        this.template.update(REMOVE_O, studyId, observationId, name);
+    }
+
+    public void removeTriggerValue(Long studyId, int interventionId, String name) {
+        this.template.update(REMOVE_T, studyId, interventionId, name);
+    }
+
+    public void removeActionValue(Long studyId, int interventionId, int actionId, String name) {
+        this.template.update(REMOVE_A, studyId, interventionId, actionId, name);
+    }
+
+    protected boolean noObservationValues() {
+        return this.template.queryForObject(
+                "SELECT count(*) AS c FROM nvpairs_observations", Integer.class) == 0;
     }
 
     void clear() {
-        this.template.execute("DELETE FROM nvpairs");
+        this.template.execute("DELETE FROM nvpairs_observations");
+        this.template.execute("DELETE FROM nvpairs_triggers");
+        this.template.execute("DELETE FROM nvpairs_actions");
     }
 }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/sdk/MoreSDK.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/sdk/MoreSDK.java
@@ -43,7 +43,7 @@ public class MoreSDK {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MoreSDK.class);
 
-    private final NameValuePairRepository nvpairs;
+    public final NameValuePairRepository nvpairs;
 
     private final SchedulingService schedulingService;
 
@@ -67,18 +67,6 @@ public class MoreSDK {
         this.elasticService = elasticService;
         this.pushNotificationService = pushNotificationService;
         this.observationRepository = observationRepository;
-    }
-
-    public <T extends Serializable> void setValue(String issuer, String name, T value) {
-        nvpairs.setValue(issuer, name, value);
-    }
-
-    public <T extends Serializable> Optional<T> getValue(String issuer, String name, Class<T> tClass) {
-        return nvpairs.getValue(issuer, name, tClass);
-    }
-
-    public void removeValue(String issuer, String name) {
-        nvpairs.removeValue(issuer, name);
     }
 
     public MoreActionSDK scopedActionSDK(Long studyId, Integer studyGroupId, int interventionId, int actionId, String actionType, int participantId) {

--- a/studymanager/src/main/java/io/redlink/more/studymanager/sdk/scoped/MoreActionSDKImpl.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/sdk/scoped/MoreActionSDKImpl.java
@@ -15,8 +15,10 @@ import io.redlink.more.studymanager.utils.LoggingUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Serializable;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Optional;
 
 public class MoreActionSDKImpl extends MorePlatformSDKImpl implements MoreActionSDK {
     private static final Logger LOGGER = LoggerFactory.getLogger(MoreActionSDKImpl.class);
@@ -32,6 +34,21 @@ public class MoreActionSDKImpl extends MorePlatformSDKImpl implements MoreAction
         this.actionId = actionId;
         this.actionType = actionType;
         this.participantId = participantId;
+    }
+
+    @Override
+    public <T extends Serializable> void setValue(String name, T value) {
+        sdk.nvpairs.setActionValue(studyId, interventionId, actionId, name, value);
+    }
+
+    @Override
+    public <T extends Serializable> Optional<T> getValue(String name, Class<T> tClass) {
+        return sdk.nvpairs.getActionValue(studyId, interventionId, actionId, name, tClass);
+    }
+
+    @Override
+    public void removeValue(String name) {
+        sdk.nvpairs.removeActionValue(studyId, interventionId, actionId, name);
     }
 
     @Override
@@ -67,10 +84,5 @@ public class MoreActionSDKImpl extends MorePlatformSDKImpl implements MoreAction
                 sdk.storeDatapoint(ElasticDataPoint.Type.action, studyId, studyGroupId, participantId, actionId, actionType, Instant.now(), Map.of("title", title, "message", message));
             }
         }
-    }
-
-    @Override
-    public String getIssuer() {
-        return studyId + "-" + studyGroupId + '-' + interventionId + "-" + actionId + "-action";
     }
 }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/sdk/scoped/MoreObservationSDKImpl.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/sdk/scoped/MoreObservationSDKImpl.java
@@ -13,6 +13,7 @@ import io.redlink.more.studymanager.core.sdk.MoreObservationSDK;
 import io.redlink.more.studymanager.model.data.ElasticDataPoint;
 import io.redlink.more.studymanager.sdk.MoreSDK;
 
+import java.io.Serializable;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
@@ -27,8 +28,18 @@ public class MoreObservationSDKImpl extends MorePlatformSDKImpl implements MoreO
     }
 
     @Override
-    public String getIssuer() {
-        return studyId + "-" + studyGroupId + '-' + observationId + "-observation";
+    public <T extends Serializable> void setValue(String name, T value) {
+        sdk.nvpairs.setObservationValue(studyId, observationId, name, value);
+    }
+
+    @Override
+    public <T extends Serializable> Optional<T> getValue(String name, Class<T> tClass) {
+        return sdk.nvpairs.getObservationValue(studyId, observationId, name, tClass);
+    }
+
+    @Override
+    public void removeValue(String name) {
+        sdk.nvpairs.removeObservationValue(studyId, observationId, name);
     }
 
     @Override

--- a/studymanager/src/main/java/io/redlink/more/studymanager/sdk/scoped/MorePlatformSDKImpl.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/sdk/scoped/MorePlatformSDKImpl.java
@@ -13,8 +13,6 @@ import io.redlink.more.studymanager.core.sdk.MorePlatformSDK;
 import io.redlink.more.studymanager.model.Participant;
 import io.redlink.more.studymanager.sdk.MoreSDK;
 
-import java.io.Serializable;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -51,21 +49,4 @@ public abstract class MorePlatformSDKImpl implements MorePlatformSDK {
                 (filter == ParticipantFilter.ACTIVE_ONLY ? Set.of(Participant.Status.ACTIVE) : null);
         return sdk.listParticipants(studyId, studyGroupId, state);
     }
-
-    @Override
-    public <T extends Serializable> void setValue(String name, T value) {
-        sdk.setValue(getIssuer(), name, value);
-    }
-
-    @Override
-    public <T extends Serializable> Optional<T> getValue(String name, Class<T> tClass) {
-        return sdk.getValue(getIssuer(), name, tClass);
-    }
-
-    @Override
-    public void removeValue(String name) {
-        sdk.removeValue(getIssuer(), name);
-    }
-
-    public abstract String getIssuer();
 }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/sdk/scoped/MoreTriggerSDKImpl.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/sdk/scoped/MoreTriggerSDKImpl.java
@@ -14,6 +14,8 @@ import io.redlink.more.studymanager.core.sdk.schedule.Schedule;
 import io.redlink.more.studymanager.sdk.MoreSDK;
 import org.apache.commons.lang3.NotImplementedException;
 
+import java.io.Serializable;
+import java.util.Optional;
 import java.util.Set;
 
 public class MoreTriggerSDKImpl extends MorePlatformSDKImpl implements MoreTriggerSDK {
@@ -23,6 +25,21 @@ public class MoreTriggerSDKImpl extends MorePlatformSDKImpl implements MoreTrigg
     public MoreTriggerSDKImpl(MoreSDK sdk, long studyId, Integer studyGroupId, int interventionId) {
         super(sdk, studyId, studyGroupId);
         this.interventionId = interventionId;
+    }
+
+    @Override
+    public <T extends Serializable> void setValue(String name, T value) {
+        sdk.nvpairs.setTriggerValue(studyId, interventionId, name, value);
+    }
+
+    @Override
+    public <T extends Serializable> Optional<T> getValue(String name, Class<T> tClass) {
+        return sdk.nvpairs.getTriggerValue(studyId, interventionId, name, tClass);
+    }
+
+    @Override
+    public void removeValue(String name) {
+        sdk.nvpairs.removeTriggerValue(studyId, interventionId, name);
     }
 
     @Override
@@ -49,8 +66,7 @@ public class MoreTriggerSDKImpl extends MorePlatformSDKImpl implements MoreTrigg
         throw new NotImplementedException();
     }
 
-    @Override
-    public String getIssuer() {
+    private String getIssuer() {
         return studyId + "-" + studyGroupId + '-' + interventionId + "-trigger";
     }
 }

--- a/studymanager/src/main/resources/db/migration/V1_14_0__add_new_nvpairs_table.sql
+++ b/studymanager/src/main/resources/db/migration/V1_14_0__add_new_nvpairs_table.sql
@@ -8,14 +8,18 @@ CREATE TABLE IF NOT EXISTS nvpairs_observations (
     FOREIGN KEY (study_id, observation_id) REFERENCES observations(study_id, observation_id) ON DELETE CASCADE
 );
 
+WITH legacy AS (
+    SELECT
+        name,
+        value,
+        CAST(substring(issuer, '^\d+') AS BIGINT) AS study_id,
+        CAST(substring(replace(issuer, 'null', '0'), '^\d+-\d+-(\d+)') AS INT) AS observation_id
+    FROM nvpairs
+    WHERE issuer LIKE '%_observation'
+)
 INSERT INTO nvpairs_observations (name, value, study_id, observation_id)
-SELECT
-    name,
-    value,
-    CAST(substring(issuer, '^\d+') AS BIGINT) AS study_id,
-    CAST(substring(replace(issuer, 'null', '0'), '^\d+-\d+-(\d+)') AS INT) AS observation_id
-FROM nvpairs
-WHERE issuer LIKE '%_observation'
+SELECT legacy.* FROM legacy
+    INNER JOIN observations ON (legacy.study_id = observations.study_id AND legacy.observation_id = observations.observation_id)
 ON CONFLICT DO NOTHING;
 
 CREATE TABLE IF NOT EXISTS nvpairs_triggers (
@@ -29,14 +33,18 @@ CREATE TABLE IF NOT EXISTS nvpairs_triggers (
     FOREIGN KEY (study_id, intervention_id) REFERENCES triggers(study_id, intervention_id) ON DELETE CASCADE
 );
 
+WITH legacy AS (
+    SELECT
+        name,
+        value,
+        CAST(substring(issuer, '^\d+') AS BIGINT) AS study_id,
+        CAST(substring(replace(issuer, 'null', '0'), '^\d+-\d+-(\d+)') AS INT) AS intervention_id
+    FROM nvpairs
+    WHERE issuer LIKE '%_trigger'
+)
 INSERT INTO nvpairs_triggers (name, value, study_id, intervention_id)
-SELECT
-    name,
-    value,
-    CAST(substring(issuer, '^\d+') AS BIGINT) AS study_id,
-    CAST(substring(replace(issuer, 'null', '0'), '^\d+-\d+-(\d+)') AS INT) AS intervention_id
-FROM nvpairs
-WHERE issuer LIKE '%_trigger'
+SELECT legacy.* FROM legacy
+    INNER JOIN triggers ON (legacy.study_id = triggers.study_id AND legacy.intervention_id = triggers.intervention_id)
 ON CONFLICT DO NOTHING;
 
 CREATE TABLE IF NOT EXISTS nvpairs_actions (
@@ -51,15 +59,19 @@ CREATE TABLE IF NOT EXISTS nvpairs_actions (
     FOREIGN KEY (study_id, intervention_id, action_id) REFERENCES actions(study_id, intervention_id, action_id) ON DELETE CASCADE
 );
 
+WITH legacy AS (
+    SELECT
+        name,
+        value,
+        CAST(substring(issuer, '^\d+') AS BIGINT) AS study_id,
+        CAST(substring(replace(issuer, 'null', '0'), '^\d+-\d+-(\d+)') AS INT) AS intervention_id,
+        CAST(substring(replace(issuer, 'null', '0'), '^\d+-\d+-\d+-(\d+)') AS INT) AS action_id
+    FROM nvpairs
+    WHERE issuer LIKE '%_action'
+)
 INSERT INTO nvpairs_actions (name, value, study_id, intervention_id, action_id)
-SELECT
-    name,
-    value,
-    CAST(substring(issuer, '^\d+') AS BIGINT) AS study_id,
-    CAST(substring(replace(issuer, 'null', '0'), '^\d+-\d+-(\d+)') AS INT) AS intervention_id,
-    CAST(substring(replace(issuer, 'null', '0'), '^\d+-\d+-\d+-(\d+)') AS INT) AS action_id
-FROM nvpairs
-WHERE issuer LIKE '%_action'
+SELECT legacy.* FROM legacy
+    INNER JOIN actions ON (legacy.study_id = actions.study_id AND legacy.intervention_id = actions.intervention_id AND legacy.action_id = actions.action_id)
 ON CONFLICT DO NOTHING;
 
 DROP TABLE nvpairs;

--- a/studymanager/src/main/resources/db/migration/V1_14_0__add_new_nvpairs_table.sql
+++ b/studymanager/src/main/resources/db/migration/V1_14_0__add_new_nvpairs_table.sql
@@ -1,0 +1,65 @@
+CREATE TABLE IF NOT EXISTS nvpairs_observations (
+    study_id BIGINT NOT NULL,
+    observation_id INT,
+    name VARCHAR,
+    value bytea NOT NULL,
+
+    PRIMARY KEY (study_id, observation_id, name),
+    FOREIGN KEY (study_id, observation_id) REFERENCES observations(study_id, observation_id) ON DELETE CASCADE
+);
+
+INSERT INTO nvpairs_observations (name, value, study_id, observation_id)
+SELECT
+    name,
+    value,
+    CAST(substring(issuer, '^\d+') AS BIGINT) AS study_id,
+    CAST(substring(replace(issuer, 'null', '0'), '^\d+-\d+-(\d+)') AS INT) AS observation_id
+FROM nvpairs
+WHERE issuer LIKE '%_observation'
+ON CONFLICT DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS nvpairs_triggers (
+    study_id BIGINT NOT NULL,
+    intervention_id INT,
+    name VARCHAR,
+    value bytea NOT NULL,
+
+    PRIMARY KEY (study_id, intervention_id, name),
+    FOREIGN KEY (study_id, intervention_id) REFERENCES interventions(study_id, intervention_id) ON DELETE CASCADE,
+    FOREIGN KEY (study_id, intervention_id) REFERENCES triggers(study_id, intervention_id) ON DELETE CASCADE
+);
+
+INSERT INTO nvpairs_triggers (name, value, study_id, intervention_id)
+SELECT
+    name,
+    value,
+    CAST(substring(issuer, '^\d+') AS BIGINT) AS study_id,
+    CAST(substring(replace(issuer, 'null', '0'), '^\d+-\d+-(\d+)') AS INT) AS intervention_id
+FROM nvpairs
+WHERE issuer LIKE '%_trigger'
+ON CONFLICT DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS nvpairs_actions (
+    study_id BIGINT NOT NULL,
+    intervention_id INT,
+    action_id INT,
+    name VARCHAR,
+    value bytea NOT NULL,
+
+    PRIMARY KEY (study_id, intervention_id, action_id, name),
+    FOREIGN KEY (study_id, intervention_id) REFERENCES interventions(study_id, intervention_id) ON DELETE CASCADE,
+    FOREIGN KEY (study_id, intervention_id, action_id) REFERENCES actions(study_id, intervention_id, action_id) ON DELETE CASCADE
+);
+
+INSERT INTO nvpairs_actions (name, value, study_id, intervention_id, action_id)
+SELECT
+    name,
+    value,
+    CAST(substring(issuer, '^\d+') AS BIGINT) AS study_id,
+    CAST(substring(replace(issuer, 'null', '0'), '^\d+-\d+-(\d+)') AS INT) AS intervention_id,
+    CAST(substring(replace(issuer, 'null', '0'), '^\d+-\d+-\d+-(\d+)') AS INT) AS action_id
+FROM nvpairs
+WHERE issuer LIKE '%_action'
+ON CONFLICT DO NOTHING;
+
+DROP TABLE nvpairs;

--- a/studymanager/src/test/java/io/redlink/more/studymanager/repository/NameValuePairRepositoryTest.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/repository/NameValuePairRepositoryTest.java
@@ -8,6 +8,11 @@
  */
 package io.redlink.more.studymanager.repository;
 
+import io.redlink.more.studymanager.model.Contact;
+import io.redlink.more.studymanager.model.Observation;
+import io.redlink.more.studymanager.model.Study;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,8 +23,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.io.Serializable;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Testcontainers
@@ -27,30 +31,44 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class NameValuePairRepositoryTest {
 
     @Autowired
+    private StudyRepository studyRepository;
+
+    @Autowired
+    private ObservationRepository observationRepository;
+
+    @Autowired
     private NameValuePairRepository nvpairs;
 
     @BeforeEach
-    void deleteAll() {
-        nvpairs.clear();
+    void before() {
+        studyRepository.clear();
+        //Test cascade deletion
+        assertTrue(nvpairs.noObservationValues());
     }
 
     @Test
-    public void testCrud() {
-        nvpairs.setValue("i1", "n1", "v1");
-        assertThat(nvpairs.getValue("i1", "n1", String.class).get()).isEqualTo("v1");
-        assertFalse(nvpairs.getValue("i1", "n2", String.class).isPresent());
-        assertFalse(nvpairs.getValue("i2", "n1", String.class).isPresent());
+    void testCrud() {
+        long sid = studyRepository.insert(new Study().setContact(new Contact())).getStudyId();
+        int oid1 = observationRepository.insert(new Observation().setStudyId(sid).setType("t").setHidden(false)).getObservationId();
+        int oid2 = observationRepository.insert(new Observation().setStudyId(sid).setType("t").setHidden(false)).getObservationId();
+
+        nvpairs.setObservationValue(sid, oid1, "n1", "v1");
+        assertThat(nvpairs.getObservationValue(sid, oid1, "n1", String.class).get()).isEqualTo("v1");
+        assertFalse(nvpairs.getObservationValue(sid, oid1, "n2", String.class).isPresent());
+        assertFalse(nvpairs.getObservationValue(sid, oid2, "n1", String.class).isPresent());
         assertThrows(ClassCastException.class, () -> {
-            nvpairs.getValue("i1", "n1", Integer.class);
+            nvpairs.getObservationValue(sid, oid1, "n1", Integer.class);
         });
-        nvpairs.removeValue("i1", "n1");
-        assertFalse(nvpairs.getValue("i1", "n1", String.class).isPresent());
+        nvpairs.removeObservationValue(sid, oid1, "n1");
+        assertFalse(nvpairs.getObservationValue(sid, oid1, "n1", String.class).isPresent());
     }
 
     @Test
     public void testMoreComplexObject() {
-        nvpairs.setValue("i2", "complex", new SampleObject("v1"));
-        assertThat(nvpairs.getValue("i2", "complex", SampleObject.class).get().getValue()).isEqualTo("v1");
+        long sid1 = studyRepository.insert(new Study().setContact(new Contact())).getStudyId();
+        int oid1 = observationRepository.insert(new Observation().setStudyId(sid1).setType("t").setHidden(false)).getObservationId();
+        nvpairs.setObservationValue(sid1, oid1, "complex", new SampleObject("v1"));
+        assertThat(nvpairs.getObservationValue(sid1, 1, "complex", SampleObject.class).get().getValue()).isEqualTo("v1");
     }
 
 }

--- a/studymanager/src/test/java/io/redlink/more/studymanager/scheduler/TestJob.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/scheduler/TestJob.java
@@ -8,7 +8,7 @@
  */
 package io.redlink.more.studymanager.scheduler;
 
-import io.redlink.more.studymanager.sdk.MoreSDK;
+import io.redlink.more.studymanager.core.sdk.MoreTriggerSDK;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
@@ -21,13 +21,13 @@ public class TestJob  implements Job {
     private static final Logger LOGGER = LoggerFactory.getLogger(TestJob.class);
 
     @Autowired
-    MoreSDK moreSDK;
+    MoreTriggerSDK moreSDK;
 
     @Override
     public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
         String issuer = jobExecutionContext.getJobDetail().getJobDataMap().getString("issuer");
-        int count = moreSDK.getValue(issuer, "i", Integer.class).orElse(0);
+        int count = moreSDK.getValue(issuer, Integer.class).orElse(0);
         LOGGER.debug("scheduled {}: count {}", issuer, count);
-        moreSDK.setValue("i", "c", count+1);
+        moreSDK.setValue(issuer, count+1);
     }
 }

--- a/studymanager/src/test/java/io/redlink/more/studymanager/scheduler/TestQrtzScheduler.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/scheduler/TestQrtzScheduler.java
@@ -8,6 +8,7 @@
  */
 package io.redlink.more.studymanager.scheduler;
 
+import io.redlink.more.studymanager.core.sdk.MoreTriggerSDK;
 import io.redlink.more.studymanager.sdk.MoreSDK;
 import org.junit.jupiter.api.Test;
 import org.quartz.*;
@@ -38,7 +39,7 @@ import static org.quartz.TriggerBuilder.newTrigger;
 public class TestQrtzScheduler {
 
     @MockBean
-    private MoreSDK moreSDK;
+    private MoreTriggerSDK moreSDK;
 
     @Autowired
     private SchedulerFactoryBean factory;
@@ -48,8 +49,8 @@ public class TestQrtzScheduler {
 
         Map<String, AtomicInteger> store = new HashMap<>();
 
-        when(moreSDK.getValue(anyString(), anyString(), any())).thenAnswer(in -> {
-            String key = in.getArgument(0) + "-" + in.getArgument(1);
+        when(moreSDK.getValue(anyString(), any())).thenAnswer(in -> {
+            String key = in.getArgument(0);
             return Optional.of(store.computeIfAbsent(key, s -> new AtomicInteger()).incrementAndGet());
         });
 
@@ -72,14 +73,14 @@ public class TestQrtzScheduler {
         scheduler.unscheduleJob(t1.getKey());
         scheduler.deleteJob(job1.getKey());
 
-        assertThat(store.get("issuer1-i").get()).isGreaterThanOrEqualTo(7);
-        assertThat(store.get("issuer2-i").get()).isGreaterThanOrEqualTo(4);
+        assertThat(store.get("issuer1").get()).isGreaterThanOrEqualTo(7);
+        assertThat(store.get("issuer2").get()).isGreaterThanOrEqualTo(4);
 
         TimeUnit.MILLISECONDS.sleep(1200);
         scheduler.unscheduleJob(t2.getKey());
         scheduler.deleteJob(job2.getKey());
 
-        assertThat(store.get("issuer2-i").get()).isEqualTo(8);
+        assertThat(store.get("issuer2").get()).isEqualTo(8);
     }
 
     private JobDetail jobDetail(String id) {
@@ -100,10 +101,10 @@ public class TestQrtzScheduler {
         TimeUnit.MILLISECONDS.sleep(500);
         scheduler.unscheduleJob(new TriggerKey(triggerId));
         scheduler.deleteJob(job.getKey());
-        verify(moreSDK, atLeast(2)).getValue(any(),any(),any());
+        verify(moreSDK, atLeast(2)).getValue(any(),any());
         reset(moreSDK);
         TimeUnit.MILLISECONDS.sleep(200);
-        verify(moreSDK, never()).getValue(any(),any(),any());
+        verify(moreSDK, never()).getValue(any(),any());
         scheduler.shutdown();
     }
 


### PR DESCRIPTION
This PR is a second attempt for #240 with an improved migration script:
> This PR fixes a possible data leak where a new observation could "inherit" the status of a previously deleted observation of the same study.

Closes #245