### PR TITLE
#249 Update Dependabot-Configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,15 +2,29 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    target-branch: 'develop'
     assignees:
       - ja-fra
     schedule:
       interval: weekly
+    groups:
+      github-action:
+        patterns:
+          - "actions/*"
+      docker:
+        patterns:
+          - "docker/*"
   - package-ecosystem: maven
     directory: /
+    target-branch: 'develop'
     schedule:
       interval: daily
     ignore:
       - # We want to stay on the v5 of the openapi-generator
         dependency-name: "org.openapitools:openapi-generator-maven-plugin"
         update-types: ["version-update:semver-major"]
+    groups:
+      maven-plugin:
+        patterns:
+          - "org.apache.maven.plugins:*"
+          - "org.codehaus.mojo:*"

--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -1,0 +1,34 @@
+name: Dependabot Automation
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  repository-projects: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot Metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Label Major Updates
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-major'}}
+        run: |
+          gh label create "major-update" --color "B60205" --description "Major Dependency Update" --repo "$REPO" || true
+          gh pr edit "$PR_URL" --add-label "major-update"
+        env:
+          REPO: ${{github.repository}}
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Enable Auto-Merge for Patch Updates
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/test-results.yaml
+++ b/.github/workflows/test-results.yaml
@@ -30,20 +30,11 @@ jobs:
 
     steps:
       - name: Download and Extract Artifacts
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: |
-          mkdir -p artifacts && cd artifacts
-          
-          artifacts_url=${{ github.event.workflow_run.artifacts_url }}
-          
-          gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
-          do
-            IFS=$'\t' read name url <<< "$artifact"
-            gh api $url > "$name.zip"
-            unzip -d "$name" "$name.zip"
-          done
-
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          run-id: ${{ github.event.workflow_run.id }}
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:


### PR DESCRIPTION
Update the Dependabot configuration:

* Dependency-Updates now target the `develop`-branch
* Group Updates for: docker, official actions, common maven plugins
* Simple Dependabot automation (auto-merge patch-updates)

Closes #249 