### PR TITLE
#191 Clear LimeSurvey reference when importing a Study

### DIFF
--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/factory/ComponentFactory.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/factory/ComponentFactory.java
@@ -77,6 +77,8 @@ public abstract class ComponentFactory<C extends Component, P extends ComponentP
         }
     }
 
+    public P preImport(P values) { return values; }
+
     public WebComponent getWebComponent() {
         return null;
     }

--- a/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyObservationFactory.java
+++ b/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyObservationFactory.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 public class LimeSurveyObservationFactory<C extends LimeSurveyObservation<P>, P extends ObservationProperties>
         extends ObservationFactory<C, P> {
 
-    private static List<Value> properties = List.of(
+    private static final List<Value> properties = List.of(
             /* TODO enable Autocomplete in FE
             new AutocompleteValue("limeSurveyId", "surveys")
                     .setName("Survey")
@@ -79,6 +79,12 @@ public class LimeSurveyObservationFactory<C extends LimeSurveyObservation<P>, P 
     @Override
     public LimeSurveyObservation<ObservationProperties> create(MoreObservationSDK sdk, ObservationProperties properties) throws ConfigurationValidationException {
         return new LimeSurveyObservation(sdk, validate((P)properties), limeSurveyRequestService);
+    }
+
+    @Override
+    public ObservationProperties preImport(ObservationProperties properties) {
+        properties.remove(LimeSurveyObservation.LIME_SURVEY_ID);
+        return properties;
     }
 
     @Override

--- a/studymanager/src/main/java/io/redlink/more/studymanager/service/ImportExportService.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/service/ImportExportService.java
@@ -99,8 +99,8 @@ public class ImportExportService {
 
     @Transactional
     public Study importStudy(StudyImportExport studyImport, AuthenticatedUser user) {
-        Study newStudy = studyService.createStudy(studyImport.getStudy(), user);
-        Long studyId = newStudy.getStudyId();
+        final Study newStudy = studyService.createStudy(studyImport.getStudy(), user);
+        final Long studyId = newStudy.getStudyId();
 
         studyImport.getStudyGroups().forEach(studyGroup ->
                 studyGroupService.importStudyGroup(studyId, studyGroup)
@@ -109,14 +109,12 @@ public class ImportExportService {
                 observationService.importObservation(studyId, observation)
         );
         studyImport.getInterventions().forEach(intervention ->
-                interventionService.importIntervention(studyId, intervention)
-        );
-        studyImport.getTriggers().forEach((interventionId, trigger) ->
-            interventionService.importTrigger(studyId, interventionId, trigger)
-        );
-        studyImport.getActions().forEach((interventionId, actionList) ->
-            actionList.forEach(action ->
-                    interventionService.importAction(studyId, interventionId, action))
+                interventionService.importIntervention(
+                        studyId,
+                        intervention,
+                        studyImport.getTriggers().get(intervention.getInterventionId()),
+                        studyImport.getActions().getOrDefault(intervention.getInterventionId(), Collections.emptyList())
+                )
         );
         return newStudy;
     }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/service/InterventionService.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/service/InterventionService.java
@@ -11,11 +11,13 @@ package io.redlink.more.studymanager.service;
 import io.redlink.more.studymanager.core.component.Component;
 import io.redlink.more.studymanager.core.exception.ConfigurationValidationException;
 import io.redlink.more.studymanager.core.factory.ActionFactory;
+import io.redlink.more.studymanager.core.factory.TriggerFactory;
+import io.redlink.more.studymanager.core.properties.ActionProperties;
+import io.redlink.more.studymanager.core.properties.TriggerProperties;
 import io.redlink.more.studymanager.core.validation.ConfigurationValidationReport;
 import io.redlink.more.studymanager.exception.BadRequestException;
 import io.redlink.more.studymanager.exception.NotFoundException;
 import io.redlink.more.studymanager.model.Action;
-import io.redlink.more.studymanager.core.factory.TriggerFactory;
 import io.redlink.more.studymanager.model.Intervention;
 import io.redlink.more.studymanager.model.Study;
 import io.redlink.more.studymanager.model.Trigger;
@@ -23,20 +25,18 @@ import io.redlink.more.studymanager.repository.InterventionRepository;
 import io.redlink.more.studymanager.repository.StudyRepository;
 import io.redlink.more.studymanager.sdk.MoreSDK;
 import io.redlink.more.studymanager.utils.LoggingUtils;
-
 import java.text.ParseException;
-
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import org.quartz.CronExpression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class InterventionService {
@@ -69,8 +69,25 @@ public class InterventionService {
         return repository.insert(intervention);
     }
 
-    public Intervention importIntervention(Long studyId, Intervention intervention) {
-        return repository.importIntervention(studyId, intervention);
+    @Transactional
+    public Intervention importIntervention(Long studyId, Intervention intervention, Trigger trigger, List<Action> actions) {
+        Intervention imported = repository.importIntervention(studyId, intervention);
+
+        {
+            Trigger validated = validateTrigger(trigger);
+            TriggerFactory factory = factory(validated);
+            validated.setProperties((TriggerProperties) factory.preImport(validated.getProperties()));
+            repository.importTrigger(studyId, imported.getInterventionId(), validateTrigger(validated));
+        }
+
+        actions.forEach(a -> {
+            Action validated = validateAction(a);
+            ActionFactory factory = factory(validated);
+            validated.setProperties((ActionProperties) factory.preImport(validated.getProperties()));
+            repository.importAction(studyId, imported.getInterventionId(), validateAction(validated));
+        });
+
+        return imported;
     }
 
     public List<Intervention> listInterventions(Long studyId) {
@@ -96,10 +113,6 @@ public class InterventionService {
         return repository.createAction(studyId, interventionId, validateAction(action));
     }
 
-    public Action importAction(Long studyId, Integer interventionId, Action action) {
-        return repository.importAction(studyId, interventionId, validateAction(action));
-    }
-
     public Action getActionByIds(Long studyId, Integer interventionId, Integer actionId) {
         return repository.getActionByIds(studyId, interventionId, actionId);
     }
@@ -121,10 +134,6 @@ public class InterventionService {
     public Trigger updateTrigger(Long studyId, Integer interventionId, Trigger trigger) {
         studyStateService.assertStudyNotInState(studyId, Study.Status.CLOSED);
         return repository.updateTrigger(studyId, interventionId, validateTrigger(trigger));
-    }
-
-    public Trigger importTrigger(Long studyId, Integer interventionId, Trigger trigger) {
-        return repository.importTrigger(studyId, interventionId, validateTrigger(trigger));
     }
 
     public Trigger getTriggerByIds(Long studyId, Integer interventionId) {

--- a/studymanager/src/main/java/io/redlink/more/studymanager/service/ObservationService.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/service/ObservationService.java
@@ -11,6 +11,7 @@ package io.redlink.more.studymanager.service;
 import io.redlink.more.studymanager.core.component.Component;
 import io.redlink.more.studymanager.core.exception.ConfigurationValidationException;
 import io.redlink.more.studymanager.core.factory.ObservationFactory;
+import io.redlink.more.studymanager.core.properties.ObservationProperties;
 import io.redlink.more.studymanager.exception.BadRequestException;
 import io.redlink.more.studymanager.exception.NotFoundException;
 import io.redlink.more.studymanager.model.Observation;
@@ -48,7 +49,11 @@ public class ObservationService {
     }
 
     public Observation importObservation(Long studyId, Observation observation) {
-        return repository.doImport(studyId, validate(observation));
+        Observation validated = validate(observation);
+        ObservationFactory factory = factory(validated);
+        ObservationProperties props = (ObservationProperties) factory.preImport(validated.getProperties());
+        validated.setProperties(props);
+        return repository.doImport(studyId, validated);
     }
 
     public void deleteObservation(Long studyId, Integer observationId) {


### PR DESCRIPTION
Introduced a `preImport()`-hook in the `ComponentFactory`s to allow additional setup when importing a study.

This hook is now used in the `LimeSurveyObservationFactory` to remove the limeSurveyId on import.

Resolves #191