### PR TITLE
#376: Wrong time slot for interventions in study timeline calendar.

### DIFF
--- a/studymanager/src/main/java/io/redlink/more/studymanager/utils/SchedulerUtils.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/utils/SchedulerUtils.java
@@ -145,6 +145,7 @@ public final class SchedulerUtils {
         if (CronExpression.isValidExpression(cronString)) {
             try {
                 CronExpression cronExpression = new CronExpression(cronString);
+                cronExpression.setTimeZone(TimeZone.getTimeZone(ZoneId.of("Europe/Vienna")));
                 Instant currentDate = cronExpression.getNextValidTimeAfter(Date.from(start)).toInstant();
                 while (currentDate.isBefore(end)) {
                     events.add(currentDate);

--- a/studymanager/src/main/java/io/redlink/more/studymanager/utils/SchedulerUtils.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/utils/SchedulerUtils.java
@@ -145,7 +145,7 @@ public final class SchedulerUtils {
         if (CronExpression.isValidExpression(cronString)) {
             try {
                 CronExpression cronExpression = new CronExpression(cronString);
-                cronExpression.setTimeZone(TimeZone.getTimeZone(ZoneId.of("Europe/Vienna")));
+                cronExpression.setTimeZone(TimeZone.getTimeZone(ZoneId.systemDefault()));
                 Instant currentDate = cronExpression.getNextValidTimeAfter(Date.from(start)).toInstant();
                 while (currentDate.isBefore(end)) {
                     events.add(currentDate);


### PR DESCRIPTION
Fixed the issue where interventions are shown in a different time slot in the Study Timeline calendar.

* Later on in the code we use Transformers.toOffsetDateTime function, where the "Europe/Vienna" timezone is hardcoded, but we need to consider this timezone in the cronExpression as well, when we calculate the interventions.
* If "Europe/Vienna" is not defined for the cronExpression, it will take the server timezone (which appears to be different), therefore the interventions were at a different time slot in the study timeline calendar.

Reference: https://github.com/MORE-Platform/more-studymanager-frontend/issues/376