### PR TITLE
#284 New Observations API Endpoint to update token label

### DIFF
--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ObservationsApiV1Controller.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ObservationsApiV1Controller.java
@@ -83,10 +83,10 @@ public class ObservationsApiV1Controller implements ObservationsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
-    public ResponseEntity<EndpointTokenDTO> createToken(Long studyId, Integer observationId, String tokenLabel) {
-        if(tokenLabel.isBlank()) { return ResponseEntity.status(HttpStatus.BAD_REQUEST).build(); }
+    public ResponseEntity<EndpointTokenDTO> createToken(Long studyId, Integer observationId, EndpointTokenDTO token) {
+        if(token.getTokenLabel().isBlank()) { return ResponseEntity.status(HttpStatus.BAD_REQUEST).build(); }
 
-        Optional<EndpointToken> addedToken = integrationService.addToken(studyId, observationId, tokenLabel.replace("\"", ""));
+        Optional<EndpointToken> addedToken = integrationService.addToken(studyId, observationId, token.getTokenLabel());
         if(addedToken.isEmpty()) {
             throw new BadRequestException("Token with given label already exists for given observation");
         }
@@ -100,17 +100,11 @@ public class ObservationsApiV1Controller implements ObservationsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
-    public ResponseEntity<EndpointTokenDTO> updateTokenLabel(Long studyId, Integer observationId, Integer tokenId, String tokenLabel) {
-        Optional<EndpointToken> token = integrationService.updateToken(studyId, observationId, tokenId, tokenLabel.replace("\"", ""));
+    public ResponseEntity<EndpointTokenDTO> updateTokenLabel(Long studyId, Integer observationId, Integer tokenId, EndpointTokenDTO endpointToken) {
+        Optional<EndpointToken> token = integrationService.updateToken(studyId, observationId, tokenId, endpointToken.getTokenLabel());
 
-        if(token.isEmpty()) {
-            throw new BadRequestException("Token with given id doesn't exist for given observation");
-        }
-
-        return ResponseEntity.ok().body(
-                EndpointTokenTransformer.toEndpointTokenDTO(
-                        token.get()
-                )
+        return ResponseEntity.of(
+                token.map(EndpointTokenTransformer::toEndpointTokenDTO)
         );
     }
 

--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ObservationsApiV1Controller.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ObservationsApiV1Controller.java
@@ -100,6 +100,22 @@ public class ObservationsApiV1Controller implements ObservationsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    public ResponseEntity<EndpointTokenDTO> updateTokenLabel(Long studyId, Integer observationId, Integer tokenId, String tokenLabel) {
+        Optional<EndpointToken> token = integrationService.updateToken(studyId, observationId, tokenId, tokenLabel.replace("\"", ""));
+
+        if(token.isEmpty()) {
+            throw new BadRequestException("Token with given id doesn't exist for given observation");
+        }
+
+        return ResponseEntity.ok().body(
+                EndpointTokenTransformer.toEndpointTokenDTO(
+                        token.get()
+                )
+        );
+    }
+
+    @Override
+    @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
     public ResponseEntity<EndpointTokenDTO> getToken(Long studyId, Integer observationId, Integer tokenId) {
 
         Optional<EndpointToken> token = integrationService.getToken(studyId, observationId, tokenId);

--- a/studymanager/src/main/java/io/redlink/more/studymanager/repository/IntegrationRepository.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/repository/IntegrationRepository.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class IntegrationRepository {
+    private static final String GET_TOKEN_BY_IDS = "SELECT * FROM observation_api_tokens WHERE study_id = ? AND observation_id = ? AND token_id = ?";
     private static final String ADD_TOKEN =
             "INSERT INTO observation_api_tokens(study_id, observation_id, token_id, token_label, token) " +
             "VALUES (:study_id, :observation_id, (SELECT COALESCE(MAX(token_id),0)+1 FROM observation_api_tokens WHERE study_id = :study_id AND observation_id = :observation_id), :token_label, :token) " +
@@ -37,7 +38,10 @@ public class IntegrationRepository {
             "DELETE FROM observation_api_tokens " +
             "WHERE study_id = ? AND observation_id = ? AND token_id = ?";
     private static final String DELETE_ALL = "DELETE FROM observation_api_tokens";
-
+    private static final String UPDATE_TOKEN =
+            "UPDATE observation_api_tokens " +
+            "SET token_label = :token_label " +
+            "WHERE study_id = :study_id AND observation_id = :observation_id AND token_id = :token_id";
     private static final String DELETE_ALL_FOR_STUDY_ID =
             "DELETE FROM observation_api_tokens " +
             "WHERE study_id = ?";
@@ -85,6 +89,25 @@ public class IntegrationRepository {
 
     public void deleteToken(Long studyId, Integer observationId, Integer tokenId) {
         template.update(DELETE_TOKEN, studyId, observationId, tokenId);
+    }
+
+    public Optional<EndpointToken> updateToken(Long studyId, Integer observationId, Integer tokenId, String tokenLabel) {
+        try {
+            namedTemplate.update(UPDATE_TOKEN,
+                    new MapSqlParameterSource()
+                            .addValue("study_id", studyId)
+                            .addValue("observation_id", observationId)
+                            .addValue("token_id", tokenId)
+                            .addValue("token_label", tokenLabel)
+                            );
+            return getById(studyId, observationId, tokenId);
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
+    }
+
+    public Optional<EndpointToken> getById(long studyId, int observationId, int tokenId) {
+        return Optional.ofNullable(template.queryForObject(GET_TOKEN_BY_IDS, getHiddenTokenRowMapper(), studyId, observationId, tokenId));
     }
 
     private static RowMapper<EndpointToken> getHiddenTokenRowMapper() {

--- a/studymanager/src/main/java/io/redlink/more/studymanager/service/IntegrationService.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/service/IntegrationService.java
@@ -70,6 +70,11 @@ public class IntegrationService {
         repository.deleteToken(studyId, observationId, tokenId);
     }
 
+    public Optional<EndpointToken> updateToken(Long studyId, Integer observationId, Integer tokenId, String tokenLabel) {
+        studyStateService.assertStudyNotInState(studyId, Study.Status.CLOSED);
+        return repository.updateToken(studyId, observationId, tokenId, tokenLabel);
+    }
+
     public void alignIntegrationsWithStudyState(Study study) {
         if(study.getStudyState() == Study.Status.CLOSED) {
             repository.clearForStudyId(study.getStudyId());

--- a/studymanager/src/main/resources/openapi/StudyManagerAPI.yaml
+++ b/studymanager/src/main/resources/openapi/StudyManagerAPI.yaml
@@ -789,6 +789,33 @@ paths:
         '404':
           description: not found
 
+    put:
+      tags:
+        - observations
+      description: Update label from observation endpoint token
+      operationId: updateTokenLabel
+      parameters:
+        - $ref: '#/components/parameters/StudyId'
+        - $ref: '#/components/parameters/ObservationId'
+        - $ref: '#/components/parameters/TokenId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TokenLabel'
+      responses:
+        '200':
+          description: Token label successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EndpointToken'
+
+        '400':
+          description: could not update observation
+        '404':
+          description: not found
 
     delete:
       tags:

--- a/studymanager/src/main/resources/openapi/StudyManagerAPI.yaml
+++ b/studymanager/src/main/resources/openapi/StudyManagerAPI.yaml
@@ -738,7 +738,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TokenLabel'
+              $ref: '#/components/schemas/EndpointToken'
       responses:
         '201':
           description: Token successfully added
@@ -803,7 +803,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TokenLabel'
+              $ref: '#/components/schemas/EndpointToken'
       responses:
         '200':
           description: Token label successfully updated
@@ -1626,21 +1626,19 @@ components:
         tokenId:
           $ref: '#/components/schemas/Id'
         tokenLabel:
-          $ref: '#/components/schemas/TokenLabel'
+          type: string
         created:
           type: string
           format: date-time
           readOnly: true
         token:
           type: string
+          readOnly: true
       required:
         - tokenId
         - tokenLabel
         - created
         - token
-
-    TokenLabel:
-      type: string
 
     ParticipationData:
       type: object

--- a/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/ObservationControllerTest.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/ObservationControllerTest.java
@@ -9,7 +9,7 @@
 package io.redlink.more.studymanager.controller.studymanager;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.redlink.more.studymanager.api.v1.model.EventDTO;
+import io.redlink.more.studymanager.api.v1.model.EndpointTokenDTO;
 import io.redlink.more.studymanager.api.v1.model.ObservationDTO;
 import io.redlink.more.studymanager.api.v1.model.ObservationScheduleDTO;
 import io.redlink.more.studymanager.model.*;
@@ -18,6 +18,7 @@ import io.redlink.more.studymanager.service.IntegrationService;
 import io.redlink.more.studymanager.service.OAuth2AuthenticationService;
 import io.redlink.more.studymanager.service.ObservationService;
 import io.redlink.more.studymanager.utils.MapperUtils;
+import java.time.OffsetDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -164,26 +165,26 @@ class ObservationControllerTest {
     @Test
     @DisplayName("Add token should create and return token with id, label, timestamp and secret set, only if label is valid")
     void testAddToken() throws Exception{
-        EndpointToken token = new EndpointToken(
+        EndpointTokenDTO token = new EndpointTokenDTO(
                 1,
                 "testLabel",
-                Instant.now(),
+                OffsetDateTime.now(),
                 "test");
         when(integrationService.addToken(anyLong(), anyInt(), anyString()))
                 .thenAnswer(invocationOnMock -> Optional.of(new EndpointToken(
-                        token.tokenId(),
+                        token.getTokenId(),
                         invocationOnMock.getArgument(2),
-                        token.created(),
-                        token.token()
+                        Instant.now(),
+                        token.getToken()
                 )));
         mvc.perform(post("/api/v1/studies/1/observations/1/tokens")
-                        .content(token.tokenLabel())
+                        .content(mapper.writeValueAsString(token))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.tokenId").value(token.tokenId()))
-                .andExpect(jsonPath("$.tokenLabel").value(token.tokenLabel()))
-                .andExpect(jsonPath("$.token").value(token.token()))
+                .andExpect(jsonPath("$.tokenId").value(token.getTokenId()))
+                .andExpect(jsonPath("$.tokenLabel").value(token.getTokenLabel()))
+                .andExpect(jsonPath("$.token").value(token.getToken()))
                 .andExpect(jsonPath("$.created").exists());
 
         mvc.perform(post("/api/v1/studies/1/observations/1/tokens")


### PR DESCRIPTION
Create new Observations API Endpoint to be able to update the observation endpoint token label.

Reference: https://github.com/MORE-Platform/more-studymanager-backend/issues/284