### PR TITLE
#298: Translate Study-States to states the app actually knows about

### DIFF
--- a/studymanager/src/main/java/io/redlink/more/studymanager/service/PushNotificationService.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/service/PushNotificationService.java
@@ -11,7 +11,9 @@ package io.redlink.more.studymanager.service;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.MessagingErrorCode;
 import io.redlink.more.studymanager.model.Notification;
+import io.redlink.more.studymanager.model.Participant;
 import io.redlink.more.studymanager.model.PushNotificationsToken;
+import io.redlink.more.studymanager.model.Study;
 import io.redlink.more.studymanager.repository.NotificationRepository;
 import io.redlink.more.studymanager.repository.PushNotificationTokenRepository;
 
@@ -86,4 +88,26 @@ public class PushNotificationService {
             return false;
         }
     }
+
+    public void sendStudyStateUpdate(Participant participant, Study.Status oldState, Study.Status newState) {
+        sendPushNotification(
+                participant.getStudyId(),
+                participant.getParticipantId(),
+                "Your Study has a new update",
+                "Your study was updated. For more information, please launch the app!",
+                Map.of("key", "STUDY_STATE_CHANGED",
+                        "oldState", toAppState(oldState),
+                        "newState", toAppState(newState))
+        );
+    }
+
+    private static String toAppState(Study.Status state) {
+        // Translate the study-states to states the app also knows:
+        return (switch (state) {
+            case ACTIVE, PREVIEW -> Study.Status.ACTIVE;
+            case PAUSED, PAUSED_PREVIEW -> Study.Status.PAUSED;
+            default -> Study.Status.CLOSED;
+        }).getValue();
+    }
+
 }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/service/StudyService.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/service/StudyService.java
@@ -131,15 +131,7 @@ public class StudyService {
                     try {
                         alignWithStudyState(s);
                         participantService.listParticipants(studyId).forEach(participant ->
-                            pushNotificationService.sendPushNotification(
-                                    studyId,
-                                    participant.getParticipantId(),
-                                    "Your Study has a new update",
-                                    "Your study was updated. For more information, please launch the app!",
-                                    Map.of("key", "STUDY_STATE_CHANGED",
-                                            "oldState", oldState.getValue(),
-                                            "newState", s.getStudyState().getValue())
-                            )
+                                pushNotificationService.sendStudyStateUpdate(participant, oldState, s.getStudyState())
                         );
                         participantService.alignParticipantsWithStudyState(s);
                         if (s.getStudyState() == Study.Status.DRAFT) {
@@ -162,14 +154,8 @@ public class StudyService {
         List<Participant> participantsToClose = participantService.listParticipantsForClosing();
         log.debug("Selected {} participants to close", participantsToClose.size());
         participantsToClose.forEach(participant -> {
-            pushNotificationService.sendPushNotification(
-                    participant.getStudyId(),
-                    participant.getParticipantId(),
-                    "Your Study has been closed",
-                    "Your study was updated. For more information, please launch the app!",
-                    Map.of("key", "STUDY_STATE_CHANGED",
-                            "oldState", Study.Status.ACTIVE.getValue(),
-                            "newState", Study.Status.CLOSED.getValue())
+            pushNotificationService.sendStudyStateUpdate(
+                    participant, Study.Status.ACTIVE, Study.Status.CLOSED
             );
             participantService.setStatus(
                     participant.getStudyId(), participant.getParticipantId(), Participant.Status.LOCKED

--- a/studymanager/src/test/java/io/redlink/more/studymanager/service/StudyServiceTest.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/service/StudyServiceTest.java
@@ -37,7 +37,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.never;
@@ -200,7 +199,7 @@ class StudyServiceTest {
                 ).alignParticipantsWithStudyState(study);
                 verify(pushNotificationService,
                         times(pt.size()).description("%s -> %s should send %d notifications".formatted(from, to, pt.size()))
-                ).sendPushNotification(eq(study.getStudyId()), anyInt(), any(), any(), any());
+                ).sendStudyStateUpdate(any(), any(), any());
 
                 // ONLY when transitioning to back to DRAFT, clear the collected data in Elastic
                 if ((from == Study.Status.PREVIEW || from == Study.Status.PAUSED_PREVIEW)


### PR DESCRIPTION
With introducing the preview, we need to translate the new states for the app:

* `PREVIEW` --> `ACTIVE`
* `PAUSED_PREVIEW` --> `PAUSED`
* `DRAFT` --> `CLOSED`

----
Closes #298 