### PR TITLE
#321: Improve API-Error-Handling on Study-Status Transitions

### DIFF
--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/exception/ConfigurationValidationException.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/exception/ConfigurationValidationException.java
@@ -9,9 +9,13 @@
 package io.redlink.more.studymanager.core.exception;
 
 import io.redlink.more.studymanager.core.validation.ConfigurationValidationReport;
+import io.redlink.more.studymanager.core.validation.ValidationIssue;
+import java.util.List;
 
 public class ConfigurationValidationException extends RuntimeException {
+
     private final ConfigurationValidationReport report;
+
     public ConfigurationValidationException(ConfigurationValidationReport report) {
         this.report = report;
     }
@@ -23,5 +27,21 @@ public class ConfigurationValidationException extends RuntimeException {
     @Override
     public String getMessage() {
         return report.toString();
+    }
+
+    public static ConfigurationValidationException of(ConfigurationValidationReport report) {
+        return new ConfigurationValidationException(report);
+    }
+
+    public static ConfigurationValidationException of(ValidationIssue issue) {
+        return of(ConfigurationValidationReport.of(issue));
+    }
+
+    public static ConfigurationValidationException of(List<ValidationIssue> issues) {
+        return of(ConfigurationValidationReport.of(issues));
+    }
+
+    public static ConfigurationValidationException ofError(String message) {
+        return of(ConfigurationValidationReport.ofError(message));
     }
 }

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/IntegerValue.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/IntegerValue.java
@@ -30,11 +30,11 @@ public class IntegerValue extends Value<Integer> {
     }
 
     @Override
-    public ValidationIssue validate(Integer integer) {
+    public ValidationIssue doValidate(Integer integer) {
         if(integer != null && (integer < getMin() || integer > getMax())) {
             return ValidationIssue.error(this, "Value must between " + getMin() + " and " + getMax());
         }
-        return validationFunction != null ? validationFunction.apply(integer) : ValidationIssue.NONE;
+        return ValidationIssue.NONE;
     }
 
     public int getMin() {

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/IntegerValue.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/IntegerValue.java
@@ -31,7 +31,7 @@ public class IntegerValue extends Value<Integer> {
 
     @Override
     public ValidationIssue doValidate(Integer integer) {
-        if(integer != null && (integer < getMin() || integer > getMax())) {
+        if (integer != null && (integer < getMin() || integer > getMax())) {
             return ValidationIssue.error(this, "Value must between " + getMin() + " and " + getMax());
         }
         return ValidationIssue.NONE;

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/StringValue.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/StringValue.java
@@ -8,9 +8,19 @@
  */
 package io.redlink.more.studymanager.core.properties.model;
 
+import io.redlink.more.studymanager.core.validation.ValidationIssue;
+
 public class StringValue extends Value<String> {
     public StringValue(String id) {
         super(id);
+    }
+
+    @Override
+    protected ValidationIssue doValidate(String s) {
+        if (isRequired() && s.trim().isEmpty()) {
+            return ValidationIssue.requiredMissing(this);
+        }
+        return super.doValidate(s);
     }
 
     @Override

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/StringValue.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/StringValue.java
@@ -17,7 +17,7 @@ public class StringValue extends Value<String> {
 
     @Override
     protected ValidationIssue doValidate(String s) {
-        if (isRequired() && s.trim().isEmpty()) {
+        if (isRequired() && (s == null || s.trim().isEmpty())) {
             return ValidationIssue.requiredMissing(this);
         }
         return super.doValidate(s);

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/validation/ConfigurationValidationReport.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/validation/ConfigurationValidationReport.java
@@ -50,7 +50,7 @@ public class ConfigurationValidationReport {
     }
 
     public boolean isValid() {
-        return issues.stream().anyMatch(i -> i.getType() != ValidationIssue.Type.None);
+        return issues.stream().noneMatch(i -> i.getType() != ValidationIssue.Type.None);
     }
 
     List<ValidationIssue> listIssues() {

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/validation/ConfigurationValidationReport.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/validation/ConfigurationValidationReport.java
@@ -16,24 +16,23 @@ public class ConfigurationValidationReport {
     private final List<ValidationIssue> issues;
 
     private ConfigurationValidationReport(List<ValidationIssue> issues) {
-        this.issues = issues;
+        this.issues = new ArrayList<>(issues);
     }
 
     public static ConfigurationValidationReport init() {
-        return new ConfigurationValidationReport(new ArrayList<>());
+        return new ConfigurationValidationReport(List.of());
     }
 
     public static ConfigurationValidationReport of(List<ValidationIssue> issues) {
-        //TODO copy
         return new ConfigurationValidationReport(issues);
     }
 
     public static ConfigurationValidationReport of(ValidationIssue issue) {
-        return new ConfigurationValidationReport(List.of(issue));
+        return of(List.of(issue));
     }
 
     public ConfigurationValidationReport error(String message) {
-        this.issues.add(ValidationIssue.error(null,message));
+        this.issues.add(ValidationIssue.error(null, message));
         return this;
     }
 
@@ -47,8 +46,9 @@ public class ConfigurationValidationReport {
     }
 
     public boolean isValid() {
-        return this.listIssues().size() == 0;
+        return issues.isEmpty();
     }
+
     List<ValidationIssue> listIssues() {
         return issues;
     }

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/validation/ConfigurationValidationReport.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/validation/ConfigurationValidationReport.java
@@ -31,6 +31,10 @@ public class ConfigurationValidationReport {
         return of(List.of(issue));
     }
 
+    public static ConfigurationValidationReport ofError(String message) {
+        return init().error(message);
+    }
+
     public ConfigurationValidationReport error(String message) {
         this.issues.add(ValidationIssue.error(null, message));
         return this;

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/validation/ConfigurationValidationReport.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/validation/ConfigurationValidationReport.java
@@ -46,7 +46,7 @@ public class ConfigurationValidationReport {
     }
 
     public boolean isValid() {
-        return issues.isEmpty();
+        return issues.stream().anyMatch(i -> i.getType() != ValidationIssue.Type.None);
     }
 
     List<ValidationIssue> listIssues() {

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/validation/ValidationIssue.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/validation/ValidationIssue.java
@@ -42,6 +42,14 @@ public class ValidationIssue {
         return new ValidationIssue(Type.WARNING, Optional.ofNullable(value).map(Value::getId).orElse(null), message);
     }
 
+    public static ValidationIssue requiredMissing(Value<?> value) {
+        return error(value, "..."); /* FIXME */
+    }
+
+    public static ValidationIssue immutablePropertyChanged(Value<?> value) {
+        return error(value, "..."); /* FIXME */
+    }
+
     public Type getType() {
         return type;
     }

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/validation/ValidationIssue.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/validation/ValidationIssue.java
@@ -43,11 +43,11 @@ public class ValidationIssue {
     }
 
     public static ValidationIssue requiredMissing(Value<?> value) {
-        return error(value, "..."); /* FIXME */
+        return error(value, "global.error.required");
     }
 
     public static ValidationIssue immutablePropertyChanged(Value<?> value) {
-        return error(value, "..."); /* FIXME */
+        return error(value, "global.error.immutable");
     }
 
     public Type getType() {

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/validation/ValidationIssue.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/validation/ValidationIssue.java
@@ -9,7 +9,6 @@
 package io.redlink.more.studymanager.core.validation;
 
 import io.redlink.more.studymanager.core.properties.model.Value;
-
 import java.util.Optional;
 
 public class ValidationIssue {
@@ -21,9 +20,9 @@ public class ValidationIssue {
 
     public static ValidationIssue NONE = new ValidationIssue(Type.None, null, null);
 
-    private Type type;
-    private String propertyId;
-    private String message;
+    private final Type type;
+    private final String propertyId;
+    private final String message;
 
     private ValidationIssue(Type type, String propertyId, String message) {
         this.type = type;
@@ -35,11 +34,11 @@ public class ValidationIssue {
         return issue != null && Type.None != issue.type;
     }
 
-    public static ValidationIssue error(Value value, String message) {
+    public static ValidationIssue error(Value<?> value, String message) {
         return new ValidationIssue(Type.ERROR, Optional.ofNullable(value).map(Value::getId).orElse(null), message);
     }
 
-    public static ValidationIssue warning(Value value, String message) {
+    public static ValidationIssue warning(Value<?> value, String message) {
         return new ValidationIssue(Type.WARNING, Optional.ofNullable(value).map(Value::getId).orElse(null), message);
     }
 

--- a/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyObservation.java
+++ b/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyObservation.java
@@ -13,6 +13,11 @@ import io.redlink.more.studymanager.core.exception.ConfigurationValidationExcept
 import io.redlink.more.studymanager.core.properties.ObservationProperties;
 import io.redlink.more.studymanager.core.sdk.MoreObservationSDK;
 import io.redlink.more.studymanager.core.sdk.MorePlatformSDK;
+import io.redlink.more.studymanager.core.validation.ConfigurationValidationReport;
+import io.redlink.more.studymanager.core.validation.ValidationIssue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -21,6 +26,7 @@ public class LimeSurveyObservation<C extends ObservationProperties> extends Obse
 
     public static final String LIME_SURVEY_ID = "limeSurveyId";
     private final LimeSurveyRequestService limeSurveyRequestService;
+    private static final Logger LOGGER = LoggerFactory.getLogger(LimeSurveyObservation.class);
 
     public LimeSurveyObservation(MoreObservationSDK sdk, C properties, LimeSurveyRequestService limeSurveyRequestService) throws ConfigurationValidationException {
         super(sdk, properties);
@@ -51,22 +57,18 @@ public class LimeSurveyObservation<C extends ObservationProperties> extends Obse
     protected String checkAndGetSurveyId() {
         String newSurveyId = properties.getString(LIME_SURVEY_ID);
         String activeSurveyId = sdk.getValue(LIME_SURVEY_ID, String.class).orElse(null);
-
-        if(activeSurveyId != null && !activeSurveyId.equals(newSurveyId)) {
-            // TODO: throw new ConfigurationValidationException(ConfigurationValidationReport.of(ValidationIssue.immutablePropertyChanged(LimeSurveyObservationFactory.limeSurveyId)));
-
-            throw new RuntimeException(String.format(
+        if (activeSurveyId != null && !activeSurveyId.equals(newSurveyId)) {
+            LOGGER.error(String.format(
                     "SurveyId on Observation %s must not be changed: %s -> %s",
                     sdk.getObservationId(),
                     activeSurveyId,
                     newSurveyId
             ));
+            throw new ConfigurationValidationException(ConfigurationValidationReport.of(ValidationIssue.immutablePropertyChanged(LimeSurveyObservationFactory.limeSurveyId)));
         } else {
             return newSurveyId;
         }
     }
-
-
 
     @Override
     public void deactivate() {

--- a/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyObservationFactory.java
+++ b/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyObservationFactory.java
@@ -20,12 +20,17 @@ import io.redlink.more.studymanager.core.properties.ObservationProperties;
 import io.redlink.more.studymanager.core.properties.model.StringValue;
 import io.redlink.more.studymanager.core.properties.model.Value;
 import io.redlink.more.studymanager.core.sdk.MoreObservationSDK;
-
 import java.util.List;
 import java.util.Optional;
 
 public class LimeSurveyObservationFactory<C extends LimeSurveyObservation<P>, P extends ObservationProperties>
         extends ObservationFactory<C, P> {
+
+    public static final Value<String> limeSurveyId = new StringValue("limeSurveyId")
+            .setName("observation.factory.limeSurvey.configProps.idName")
+            .setDescription("observation.factory.limeSurvey.configProps.idDesc")
+            .setRequired(true)
+            .setImmutable(true);
 
     private static final List<Value> properties = List.of(
             /* TODO enable Autocomplete in FE
@@ -34,10 +39,7 @@ public class LimeSurveyObservationFactory<C extends LimeSurveyObservation<P>, P 
                     .setDescription("An existing survey")
                     .setRequired(true)
              */
-            new StringValue("limeSurveyId")
-                    .setName("observation.factory.limeSurvey.configProps.idName")
-                    .setDescription("observation.factory.limeSurvey.configProps.idDesc")
-                    .setRequired(true)
+            limeSurveyId
     );
 
     private LimeSurveyRequestService limeSurveyRequestService;

--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ComponentApiV1Controller.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ComponentApiV1Controller.java
@@ -9,7 +9,10 @@
 package io.redlink.more.studymanager.controller.studymanager;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.redlink.more.studymanager.api.v1.model.*;
+import io.redlink.more.studymanager.api.v1.model.ComponentFactoryDTO;
+import io.redlink.more.studymanager.api.v1.model.ComponentFactoryMeasurementsInnerDTO;
+import io.redlink.more.studymanager.api.v1.model.ValidationReportDTO;
+import io.redlink.more.studymanager.api.v1.model.VisibilityDTO;
 import io.redlink.more.studymanager.api.v1.webservices.ComponentsApi;
 import io.redlink.more.studymanager.core.exception.ApiCallException;
 import io.redlink.more.studymanager.core.exception.ConfigurationValidationException;
@@ -21,18 +24,18 @@ import io.redlink.more.studymanager.core.io.Visibility;
 import io.redlink.more.studymanager.core.model.User;
 import io.redlink.more.studymanager.core.properties.ComponentProperties;
 import io.redlink.more.studymanager.core.webcomponent.WebComponent;
+import io.redlink.more.studymanager.model.transformer.ValidationReportTransformer;
 import io.redlink.more.studymanager.service.OAuth2AuthenticationService;
 import io.redlink.more.studymanager.utils.MapperUtils;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping(value = "/api/v1", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -73,15 +76,7 @@ public class ComponentApiV1Controller implements ComponentsApi {
                         f.validate((ComponentProperties) MapperUtils.MAPPER.convertValue(body, f.getPropertyClass()));
                         return new ValidationReportDTO().valid(true);
                     } catch (ConfigurationValidationException e) {
-                        return new ValidationReportDTO()
-                                .valid(false)
-                                .errors(e.getReport().getErrors().stream()
-                                        .map(i -> new ValidationReportItemDTO().message(i.getMessage()).propertyId(i.getPropertyId()).type("error"))
-                                        .toList()
-                                ).warnings(e.getReport().getWarnings().stream()
-                                        .map(i -> new ValidationReportItemDTO().message(i.getMessage()).propertyId(i.getPropertyId()).type("warning"))
-                                        .toList()
-                                );
+                        return ValidationReportTransformer.validationReportDTO_V1(e);
                     }
                 })
                 .map(ResponseEntity::ok)

--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ComponentApiV1Controller.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ComponentApiV1Controller.java
@@ -80,7 +80,7 @@ public class ComponentApiV1Controller implements ComponentsApi {
                     }
                 })
                 .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+                .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
     @Override

--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ExceptionControllerAdvice.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ExceptionControllerAdvice.java
@@ -23,8 +23,7 @@ public class ExceptionControllerAdvice {
     public ResponseEntity<ValidationReportDTO> handleConfigurationValidationException(ConfigurationValidationException e) {
         return ResponseEntity.status(HttpStatus.CONFLICT)
                 .header("Error-Message", e.getMessage())
-                .body(ValidationReportTransformer.validationReportDTO_V1(e))
-                ;
+                .body(ValidationReportTransformer.validationReportDTO_V1(e));
     }
 
 }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ExceptionControllerAdvice.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ExceptionControllerAdvice.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Elastic License 2.0.
+ */
+package io.redlink.more.studymanager.controller.studymanager;
+
+import io.redlink.more.studymanager.api.v1.model.ValidationReportDTO;
+import io.redlink.more.studymanager.core.exception.ConfigurationValidationException;
+import io.redlink.more.studymanager.model.transformer.ValidationReportTransformer;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice(basePackageClasses = ExceptionControllerAdvice.class)
+public class ExceptionControllerAdvice {
+
+    @ExceptionHandler(ConfigurationValidationException.class)
+    public ResponseEntity<ValidationReportDTO> handleConfigurationValidationException(ConfigurationValidationException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .header("Error-Message", e.getMessage())
+                .body(ValidationReportTransformer.validationReportDTO_V1(e))
+                ;
+    }
+
+}

--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/StudyApiV1Controller.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/StudyApiV1Controller.java
@@ -17,6 +17,7 @@ import io.redlink.more.studymanager.model.StudyRole;
 import io.redlink.more.studymanager.model.transformer.StudyTransformer;
 import io.redlink.more.studymanager.service.OAuth2AuthenticationService;
 import io.redlink.more.studymanager.service.StudyService;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -24,8 +25,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping(value = "/api/v1", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -92,9 +91,12 @@ public class StudyApiV1Controller implements StudiesApi {
 
     @Override
     @RequiresStudyRole(StudyRole.STUDY_ADMIN)
-    public ResponseEntity<Void> setStatus(Long studyId, StatusChangeDTO statusChangeDTO) {
+    public ResponseEntity<StudyDTO> setStatus(Long studyId, StatusChangeDTO statusChangeDTO) {
         final var currentUser = authService.getCurrentUser();
-        service.setStatus(studyId, StudyTransformer.fromStatusChangeDTO_V1(statusChangeDTO), currentUser);
-        return ResponseEntity.ok().build();
+
+        return ResponseEntity.of(
+                service.setStatus(studyId, StudyTransformer.fromStatusChangeDTO_V1(statusChangeDTO), currentUser)
+                        .map(StudyTransformer::toStudyDTO_V1)
+        );
     }
 }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/ContactTransformer.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/ContactTransformer.java
@@ -11,7 +11,7 @@ package io.redlink.more.studymanager.model.transformer;
 import io.redlink.more.studymanager.api.v1.model.ContactDTO;
 import io.redlink.more.studymanager.model.Contact;
 
-public class ContactTransformer {
+public final class ContactTransformer {
 
     public static ContactDTO toContactDTO_V1(Contact contact) {
         return new ContactDTO()

--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/ImportExportTransformer.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/ImportExportTransformer.java
@@ -14,12 +14,11 @@ import io.redlink.more.studymanager.api.v1.model.ParticipantInfoDTO;
 import io.redlink.more.studymanager.api.v1.model.StudyImportExportDTO;
 import io.redlink.more.studymanager.model.IntegrationInfo;
 import io.redlink.more.studymanager.model.StudyImportExport;
-
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-public class ImportExportTransformer {
+public final class ImportExportTransformer {
 
     private ImportExportTransformer() {}
 

--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/ValidationReportTransformer.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/ValidationReportTransformer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Elastic License 2.0.
+ */
+package io.redlink.more.studymanager.model.transformer;
+
+import io.redlink.more.studymanager.api.v1.model.ValidationReportDTO;
+import io.redlink.more.studymanager.api.v1.model.ValidationReportItemDTO;
+import io.redlink.more.studymanager.core.exception.ConfigurationValidationException;
+import io.redlink.more.studymanager.core.validation.ConfigurationValidationReport;
+import io.redlink.more.studymanager.core.validation.ValidationIssue;
+import java.util.List;
+
+public final class ValidationReportTransformer {
+
+    private ValidationReportTransformer() {
+    }
+
+    public static ValidationReportDTO validationReportDTO_V1(ConfigurationValidationException validation) {
+        return validationReportDTO_V1(validation.getReport())
+                .valid(false);
+    }
+
+    public static ValidationReportDTO validationReportDTO_V1(ConfigurationValidationReport report) {
+        return new ValidationReportDTO()
+                .valid(report.isValid())
+                .errors(validationReportItemDTO_V1(report.getErrors(), "error"))
+                .warnings(validationReportItemDTO_V1(report.getWarnings(), "warning"));
+    }
+
+    private static List<ValidationReportItemDTO> validationReportItemDTO_V1(List<ValidationIssue> issues, String type) {
+        return issues.stream()
+                .map(i -> validationReportItemDTO_V1(i, type))
+                .toList();
+    }
+
+    private static ValidationReportItemDTO validationReportItemDTO_V1(ValidationIssue issue, String type) {
+        return new ValidationReportItemDTO()
+                .message(issue.getMessage())
+                .propertyId(issue.getPropertyId())
+                .type(type);
+    }
+
+}

--- a/studymanager/src/main/java/io/redlink/more/studymanager/service/InterventionService.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/service/InterventionService.java
@@ -14,7 +14,6 @@ import io.redlink.more.studymanager.core.factory.ActionFactory;
 import io.redlink.more.studymanager.core.factory.TriggerFactory;
 import io.redlink.more.studymanager.core.properties.ActionProperties;
 import io.redlink.more.studymanager.core.properties.TriggerProperties;
-import io.redlink.more.studymanager.core.validation.ConfigurationValidationReport;
 import io.redlink.more.studymanager.exception.BadRequestException;
 import io.redlink.more.studymanager.exception.NotFoundException;
 import io.redlink.more.studymanager.model.Action;
@@ -215,7 +214,7 @@ public class InterventionService {
                 try {
                     CronExpression.validateExpression(trigger.getProperties().get("cronSchedule").toString());
                 } catch (ParseException e) {
-                    throw new ConfigurationValidationException(ConfigurationValidationReport.init().error(e.getMessage()));
+                    throw ConfigurationValidationException.ofError(e.getMessage());
                 }
             }
         } catch (ConfigurationValidationException e) {

--- a/studymanager/src/main/resources/openapi/StudyManagerAPI.yaml
+++ b/studymanager/src/main/resources/openapi/StudyManagerAPI.yaml
@@ -11,21 +11,13 @@ servers:
     description: Local Test Server
 paths:
   /components/{componentType}:
+    parameters:
+      - $ref: '#/components/parameters/ComponentType'
     get:
       tags:
         - components
       operationId: listComponents
       description: List component of certain type
-      parameters:
-        - name: componentType
-          in: path
-          schema:
-            type: string
-            enum:
-              - action
-              - trigger
-              - observation
-          required: true
       responses:
         '200':
           description: Components successfully returned
@@ -37,26 +29,18 @@ paths:
                   $ref: '#/components/schemas/ComponentFactory'
 
   /components/{componentType}/{componentId}/validate:
+    parameters:
+      - $ref: '#/components/parameters/ComponentType'
+      - name: componentId
+        in: path
+        schema:
+          type: string
+        required: true
     post:
       tags:
         - components
       description: check if properties are valid for component
       operationId: validateProperties
-      parameters:
-        - name: componentType
-          in: path
-          schema:
-            type: string
-            enum:
-              - action
-              - trigger
-              - observation
-          required: true
-        - name: componentId
-          in: path
-          schema:
-            type: string
-          required: true
       requestBody:
         content:
           application/json:
@@ -73,31 +57,23 @@ paths:
           description: Not found
 
   /components/{componentType}/{componentId}/api/{slug}:
+    parameters:
+      - $ref: '#/components/parameters/ComponentType'
+      - name: componentId
+        in: path
+        schema:
+          type: string
+        required: true
+      - name: slug
+        in: path
+        schema:
+          type: string
+        required: true
     post:
       tags:
         - components
       operationId: accessModuleSpecificEndpoint
       description: access module specific endpoint
-      parameters:
-        - name: componentType
-          in: path
-          schema:
-            type: string
-            enum:
-              - action
-              - trigger
-              - observation
-          required: true
-        - name: componentId
-          in: path
-          schema:
-            type: string
-          required: true
-        - name: slug
-          in: path
-          schema:
-            type: string
-          required: true
       requestBody:
         required: true
         content:
@@ -117,26 +93,18 @@ paths:
           description: Error
 
   /components/{componentType}/{componentId}/web-component.js:
+    parameters:
+      - $ref: '#/components/parameters/ComponentType'
+      - name: componentId
+        in: path
+        schema:
+          type: string
+        required: true
     get:
       tags:
         - components
       operationId: getWebComponentScript
       description: Get web component script
-      parameters:
-        - name: componentType
-          in: path
-          schema:
-            type: string
-            enum:
-              - action
-              - trigger
-              - observation
-          required: true
-        - name: componentId
-          in: path
-          schema:
-            type: string
-          required: true
       responses:
         '200':
           description: Returned script successfully
@@ -253,10 +221,20 @@ paths:
             schema:
               $ref: '#/components/schemas/StatusChange'
       responses:
-        '202':
-          description: Status changed deleted
+        '200':
+          description: Study status changed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Study'
         '400':
-          description: Bad request
+          description: The requested transition is not allowed
+        '409':
+          description: Could not update status due to configuration error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationReport'
 
   /studies/{studyId}/collaborators:
     parameters:
@@ -1500,7 +1478,6 @@ components:
         - active
         - paused
         - closed
-      readOnly: true
       default: draft
 
     StudyGroup:
@@ -2136,6 +2113,16 @@ components:
         - date
 
   parameters:
+    ComponentType:
+      name: componentType
+      in: path
+      schema:
+        type: string
+        enum:
+          - action
+          - trigger
+          - observation
+      required: true
     StudyId:
       name: studyId
       in: path


### PR DESCRIPTION
Send proper error-responses when study-status can't be changed because of incomplete/invalid configuration:

* `HTTP-400` for invalid state-transitions
* `HTTP-409` if you try to start a study with incomplete configuration (`ConfigurationValidationException`)

----
Closes #321 