### PR TITLE
#317: Data download improvements

### DIFF
--- a/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/PolarVerityObservation.java
+++ b/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/PolarVerityObservation.java
@@ -44,9 +44,9 @@ public class PolarVerityObservation<C extends ObservationProperties> extends Obs
 
         DataViewInfoType(String i18nKey, DataView.ChartType chartType, ViewConfig viewConfig) {
             this(
-                    "data.charts.polarVerity.%s.label".formatted(i18nKey),
-                    "data.charts.polarVerity.%s.title".formatted(i18nKey),
-                    "data.charts.polarVerity.%s.description".formatted(i18nKey),
+                    "monitoring.charts.polarVerity.%s.label".formatted(i18nKey),
+                    "monitoring.charts.polarVerity.%s.title".formatted(i18nKey),
+                    "monitoring.charts.polarVerity.%s.description".formatted(i18nKey),
                     chartType,
                     viewConfig
             );

--- a/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/QuestionObservation.java
+++ b/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/QuestionObservation.java
@@ -65,9 +65,9 @@ public class QuestionObservation<C extends ObservationProperties> extends Observ
 
         DataViewInfoType(String i18nKey, DataView.ChartType chartType, ViewConfig viewConfig) {
             this(
-                    "data.charts.simpleQuestion.%s.label".formatted(i18nKey),
-                    "data.charts.simpleQuestion.%s.title".formatted(i18nKey),
-                    "data.charts.simpleQuestion.%s.description".formatted(i18nKey),
+                    "monitoring.charts.simpleQuestion.%s.label".formatted(i18nKey),
+                    "monitoring.charts.simpleQuestion.%s.title".formatted(i18nKey),
+                    "monitoring.charts.simpleQuestion.%s.description".formatted(i18nKey),
                     chartType,
                     viewConfig
             );

--- a/studymanager/pom.xml
+++ b/studymanager/pom.xml
@@ -260,6 +260,7 @@
                             <schemaMappings>
                                 <schemaMapping>Instant=java.time.Instant</schemaMapping>
                                 <schemaMapping>LocalTime=java.time.LocalTime</schemaMapping>
+                                <schemaMapping>DataExport=org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody</schemaMapping>
                             </schemaMappings>
                             <importMappings>
                                 <importMapping>Instant=java.time.Instant</importMapping>

--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ImportExportApiV1Controller.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ImportExportApiV1Controller.java
@@ -21,32 +21,29 @@ import io.redlink.more.studymanager.repository.DownloadTokenRepository;
 import io.redlink.more.studymanager.service.ImportExportService;
 import io.redlink.more.studymanager.service.OAuth2AuthenticationService;
 import io.redlink.more.studymanager.utils.MapperUtils;
-import jakarta.servlet.ServletOutputStream;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
-import org.springframework.http.*;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.io.IOException;
-import java.io.OutputStream;
-import java.io.PrintWriter;
-import java.time.Instant;
 import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 
 
 @RestController
 @RequestMapping(value = "/api/v1")
 public class ImportExportApiV1Controller implements ImportExportApi {
+    private static final Logger LOGGER = LoggerFactory.getLogger(StudyApiV1Controller.class);
 
     private final ImportExportService service;
 
@@ -107,7 +104,13 @@ public class ImportExportApiV1Controller implements ImportExportApi {
                     .ok()
                     .headers(responseHeaders)
                     .contentType(MediaType.APPLICATION_JSON)
-                    .body(outputStream -> service.exportStudyData(outputStream, studyId, studyGroupId, participantId, observationId, from, to));
+                    .body(outputStream -> {
+                        try {
+                            service.exportStudyData(outputStream, studyId, studyGroupId, participantId, observationId, from, to);
+                        } catch (Exception e) {
+                            LOGGER.warn("Error exporting study data for study_{}: {}", studyId, e.getMessage(), e);
+                        }
+                    });
         } else {
             return ResponseEntity.notFound().build();
         }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ImportExportApiV1Controller.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ImportExportApiV1Controller.java
@@ -35,7 +35,7 @@ import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBo
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.io.IOException;
-import java.time.LocalDate;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -93,7 +93,7 @@ public class ImportExportApiV1Controller implements ImportExportApi {
     }
 
     @Override
-    public ResponseEntity<StreamingResponseBody> exportStudyData(Long studyId, String token, List<Integer> studyGroupId, List<Integer> participantId, List<Integer> observationId, LocalDate from, LocalDate to) {
+    public ResponseEntity<StreamingResponseBody> exportStudyData(Long studyId, String token, List<Integer> studyGroupId, List<Integer> participantId, List<Integer> observationId, Instant from, Instant to) {
         Optional<DownloadToken> dt = tokenRepository.getToken(token).filter(t -> t.getStudyId().equals(studyId));
 
         if (dt.isPresent()) {
@@ -118,7 +118,7 @@ public class ImportExportApiV1Controller implements ImportExportApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
-    public ResponseEntity<GenerateDownloadToken200ResponseDTO> generateDownloadToken(Long studyId, List<Integer> studyGroupId, List<Integer> participantId, List<Integer> observationId, LocalDate from, LocalDate to) {
+    public ResponseEntity<GenerateDownloadToken200ResponseDTO> generateDownloadToken(Long studyId, List<Integer> studyGroupId, List<Integer> participantId, List<Integer> observationId, Instant from, Instant to) {
         var token = tokenRepository.createToken(studyId).getToken();
         var uri = ServletUriComponentsBuilder.fromCurrentRequest().pathSegment(token).build(true).toUri();
 

--- a/studymanager/src/main/java/io/redlink/more/studymanager/service/ElasticService.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/service/ElasticService.java
@@ -43,7 +43,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.time.LocalDate;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -329,7 +328,7 @@ public class ElasticService {
         }
     }
 
-    public void exportData(OutputStream outputStream, Long studyId, List<Integer> studyGroupId, List<Integer> participantId, List<Integer> observationId, LocalDate from, LocalDate to) throws IOException {
+    public void exportData(OutputStream outputStream, Long studyId, List<Integer> studyGroupId, List<Integer> participantId, List<Integer> observationId, Instant from, Instant to) throws IOException {
         String index = getStudyIdString(studyId);
 
         if(!client.indices().exists(e -> e.index(index)).value()) {
@@ -359,7 +358,7 @@ public class ElasticService {
         outputStream.write(datapoints.getBytes(StandardCharsets.UTF_8));
     }
 
-    private SearchRequest getQuery(String index, List<Integer> studyGroupIds, List<Integer> participantIds, List<Integer> observationIds, LocalDate from, LocalDate to, List<FieldValue> searchAfterSort) {
+    private SearchRequest getQuery(String index, List<Integer> studyGroupIds, List<Integer> participantIds, List<Integer> observationIds, Instant from, Instant to, List<FieldValue> searchAfterSort) {
         SearchRequest.Builder builder = new SearchRequest.Builder();
         BoolQuery.Builder boolQueryBuilder = new BoolQuery.Builder();
 

--- a/studymanager/src/main/java/io/redlink/more/studymanager/service/ElasticService.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/service/ElasticService.java
@@ -14,7 +14,9 @@ import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermsQueryField;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
@@ -22,6 +24,7 @@ import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.indices.CloseIndexRequest;
 import co.elastic.clients.elasticsearch.indices.DeleteIndexRequest;
 import co.elastic.clients.elasticsearch.indices.ExistsRequest;
+import co.elastic.clients.json.JsonData;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Iterables;
 import io.redlink.more.studymanager.core.io.TimeRange;
@@ -31,22 +34,20 @@ import io.redlink.more.studymanager.model.data.ParticipationData;
 import io.redlink.more.studymanager.model.data.SimpleDataPoint;
 import io.redlink.more.studymanager.properties.ElasticProperties;
 import io.redlink.more.studymanager.utils.MapperUtils;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.*;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 @Service
 @EnableConfigurationProperties({ElasticProperties.class})
@@ -328,23 +329,23 @@ public class ElasticService {
         }
     }
 
-    public void exportData(Long studyId, OutputStream outputStream) throws IOException {
+    public void exportData(OutputStream outputStream, Long studyId, List<Integer> studyGroupId, List<Integer> participantId, List<Integer> observationId, LocalDate from, LocalDate to) throws IOException {
         String index = getStudyIdString(studyId);
 
         if(!client.indices().exists(e -> e.index(index)).value()) {
             return;
         }
 
-        SearchRequest request = getQuery(index, null);
+        SearchRequest request = getQuery(index, studyGroupId, participantId, observationId, from, to, null);
         SearchResponse<JsonNode> rsp = client.search(request, JsonNode.class);
 
         while (rsp.hits().hits().size() > 0) {
             writeHits(rsp.hits().hits(), outputStream);
             outputStream.flush();
             List<FieldValue> searchAfterSort = Iterables.getLast(rsp.hits().hits()).sort();
-            request = getQuery(index, searchAfterSort);
+            request = getQuery(index, studyGroupId, participantId, observationId, from, to, searchAfterSort);
             rsp = client.search(request, JsonNode.class);
-            if(rsp.hits().hits().size() > 0) {
+            if (rsp.hits().hits().size() > 0) {
                 outputStream.write(",".getBytes(StandardCharsets.UTF_8));
             }
         }
@@ -358,20 +359,45 @@ public class ElasticService {
         outputStream.write(datapoints.getBytes(StandardCharsets.UTF_8));
     }
 
-    private SearchRequest getQuery(String index, List<FieldValue> searchAfterSort) {
+    private SearchRequest getQuery(String index, List<Integer> studyGroupIds, List<Integer> participantIds, List<Integer> observationIds, LocalDate from, LocalDate to, List<FieldValue> searchAfterSort) {
         SearchRequest.Builder builder = new SearchRequest.Builder();
+        BoolQuery.Builder boolQueryBuilder = new BoolQuery.Builder();
+
+        if (studyGroupIds != null && !studyGroupIds.isEmpty()) {
+            List<String> studyGroupIdsStrings = studyGroupIds.stream()
+                    .map(ElasticService::getStudyGroupIdString)
+                    .toList();
+            boolQueryBuilder.filter(f -> f.terms(t -> t.field("study_group_id").terms(TermsQueryField.of(tf -> tf.value(studyGroupIdsStrings.stream().map(FieldValue::of).collect(Collectors.toList()))))));
+        }
+
+        if (participantIds != null && !participantIds.isEmpty()) {
+            List<String> participantIdStrings = participantIds.stream()
+                    .map(ElasticService::getParticipantIdString)
+                    .toList();
+            boolQueryBuilder.filter(f -> f.terms(t -> t.field("participant_id").terms(TermsQueryField.of(tf -> tf.value(participantIdStrings.stream().map(FieldValue::of).collect(Collectors.toList()))))));
+        }
+
+        if (observationIds != null && !observationIds.isEmpty()) {
+            boolQueryBuilder.filter(f -> f.terms(t -> t.field("observation_id").terms(v -> v.value(observationIds.stream().map(FieldValue::of).collect(Collectors.toList())))));
+        }
+
+        if (from != null && to != null) {
+            boolQueryBuilder.filter(f -> f.range(r -> r.field("effective_time_frame").gte(JsonData.of(from)).lte(JsonData.of(to))));
+        }
+
         builder.index(index)
-                .query(q -> q.matchAll(m -> m))
-                //.pit(p -> p.id(pitId).keepAlive(k -> k.time("1m")))
+                .query(q -> q.bool(boolQueryBuilder.build()))
                 .sort(s -> s.field(f -> f.field("effective_time_frame").order(SortOrder.Asc)))
+                .sort(s -> s.field(f -> f.field("datapoint_id.keyword").order(SortOrder.Asc)))
                 .size(BATCH_SIZE_FOR_EXPORT_REQUESTS);
 
-        if(searchAfterSort != null) {
+        if (searchAfterSort != null) {
             builder.searchAfter(searchAfterSort);
         }
 
         return builder.build();
     }
+
 
     public List<SimpleDataPoint> listDataPoints(
             Long studyId, Integer participantId, Integer observationId, String isoDate, int size) throws IOException {

--- a/studymanager/src/main/java/io/redlink/more/studymanager/service/ImportExportService.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/service/ImportExportService.java
@@ -10,7 +10,6 @@ package io.redlink.more.studymanager.service;
 
 import io.redlink.more.studymanager.exception.NotFoundException;
 import io.redlink.more.studymanager.model.*;
-import jakarta.servlet.ServletOutputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,7 +21,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
 import java.util.*;
 
 @Service
@@ -151,19 +152,19 @@ public class ImportExportService {
         return newStudy;
     }
 
-    public void exportStudyData(ServletOutputStream outputStream, Long studyId) {
+    public void exportStudyData(OutputStream outputStream, Long studyId, List<Integer> studyGroupId, List<Integer> participantId, List<Integer> observationId, LocalDate from, LocalDate to) {
         if (studyService.existsStudy(studyId).orElse(false)) {
-            exportStudyDataAsync(outputStream, studyId);
+            exportStudyDataAsync(outputStream, studyId, studyGroupId, participantId, observationId, from, to);
         } else {
             throw NotFoundException.Study(studyId);
         }
     }
 
     @Async
-    public void exportStudyDataAsync(ServletOutputStream outputStream, Long studyId) {
+    public void exportStudyDataAsync(OutputStream outputStream, Long studyId, List<Integer> studyGroupId, List<Integer> participantId, List<Integer> observationId, LocalDate from, LocalDate to) {
         try (outputStream) {
             outputStream.write("[".getBytes(StandardCharsets.UTF_8));
-            elasticService.exportData(studyId, outputStream);
+            elasticService.exportData(outputStream, studyId, studyGroupId, participantId, observationId, from, to);
             outputStream.write("]".getBytes(StandardCharsets.UTF_8));
         } catch (IOException e) {
             LOGGER.error("Cannot export study data for {}", studyId, e);

--- a/studymanager/src/main/java/io/redlink/more/studymanager/service/ImportExportService.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/service/ImportExportService.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import java.time.LocalDate;
+import java.time.Instant;
 import java.util.*;
 
 @Service
@@ -152,7 +152,7 @@ public class ImportExportService {
         return newStudy;
     }
 
-    public void exportStudyData(OutputStream outputStream, Long studyId, List<Integer> studyGroupId, List<Integer> participantId, List<Integer> observationId, LocalDate from, LocalDate to) {
+    public void exportStudyData(OutputStream outputStream, Long studyId, List<Integer> studyGroupId, List<Integer> participantId, List<Integer> observationId, Instant from, Instant to) {
         if (studyService.existsStudy(studyId).orElse(false)) {
             exportStudyDataAsync(outputStream, studyId, studyGroupId, participantId, observationId, from, to);
         } else {
@@ -161,7 +161,7 @@ public class ImportExportService {
     }
 
     @Async
-    public void exportStudyDataAsync(OutputStream outputStream, Long studyId, List<Integer> studyGroupId, List<Integer> participantId, List<Integer> observationId, LocalDate from, LocalDate to) {
+    public void exportStudyDataAsync(OutputStream outputStream, Long studyId, List<Integer> studyGroupId, List<Integer> participantId, List<Integer> observationId, Instant from, Instant to) {
         try (outputStream) {
             outputStream.write("[".getBytes(StandardCharsets.UTF_8));
             elasticService.exportData(outputStream, studyId, studyGroupId, participantId, observationId, from, to);

--- a/studymanager/src/main/resources/application.yaml
+++ b/studymanager/src/main/resources/application.yaml
@@ -50,6 +50,9 @@ spring:
   flyway:
     out-of-order: true
 
+  mvc:
+    async:
+      request-timeout: -1
 server:
   forward-headers-strategy: framework
   error:

--- a/studymanager/src/main/resources/openapi/StudyManagerAPI.yaml
+++ b/studymanager/src/main/resources/openapi/StudyManagerAPI.yaml
@@ -1095,7 +1095,7 @@ paths:
       operationId: exportStudy
       responses:
         '200':
-          description: foo
+          description: Operation successful
           content:
             application/json:
               schema:
@@ -1110,10 +1110,39 @@ paths:
       tags:
         - importExport
       operationId: generateDownloadToken
-      description: generate a download token that can be used once for download and is valid for 10 minutes
+      description: Generate a download token that can be used once for download and is valid for 10 minutes
+      parameters:
+        - name: studyGroupId
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+        - name: participantId
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+        - name: observationId
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+        - name: from
+          in: query
+          schema:
+            type: string
+            format: date
+        - name: to
+          in: query
+          schema:
+            type: string
+            format: date
       responses:
         '200':
-          description: foo
+          description: Operation successful
           content:
             application/json:
               schema:
@@ -1121,6 +1150,58 @@ paths:
                 properties:
                   token:
                     type: string
+        '404':
+          description: study not found
+
+  /studies/{studyId}/export/studydata/{token}:
+    parameters:
+      - $ref: '#/components/parameters/StudyId'
+      - name: token
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - importExport
+      description: Download Study data
+      operationId: exportStudyData
+      parameters:
+        - name: studyGroupId
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+        - name: participantId
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+        - name: observationId
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+        - name: from
+          in: query
+          schema:
+            type: string
+            format: date
+        - name: to
+          in: query
+          schema:
+            type: string
+            format: date
+      responses:
+        '200':
+          description: Operation successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataExport'
         '404':
           description: study not found
 
@@ -1157,7 +1238,7 @@ paths:
       operationId: exportParticipants
       responses:
         '200':
-          description: foo
+          description: Operation successful
           content:
             text/csv:
               schema:
@@ -2134,6 +2215,31 @@ components:
       required:
         - version
         - date
+    DataExport:
+      type: array
+      items:
+        type: object
+        properties:
+          datapoint_id:
+            type: string
+          participant_id:
+            type: string
+          study_id:
+            type: string
+          study_group_id:
+            type: string
+            nullable: true
+          observation_id:
+            type: string
+          observation_type:
+            type: string
+          data_type:
+            type: string
+          storage_date:
+            type: string
+          effective_time_frame:
+            type: string
+        additionalProperties: true
 
   parameters:
     StudyId:

--- a/studymanager/src/main/resources/openapi/StudyManagerAPI.yaml
+++ b/studymanager/src/main/resources/openapi/StudyManagerAPI.yaml
@@ -1130,16 +1130,8 @@ paths:
             type: array
             items:
               type: integer
-        - name: from
-          in: query
-          schema:
-            type: string
-            format: date
-        - name: to
-          in: query
-          schema:
-            type: string
-            format: date
+        - $ref: '#/components/parameters/From'
+        - $ref: '#/components/parameters/To'
       responses:
         '200':
           description: Operation successful
@@ -1185,16 +1177,8 @@ paths:
             type: array
             items:
               type: integer
-        - name: from
-          in: query
-          schema:
-            type: string
-            format: date
-        - name: to
-          in: query
-          schema:
-            type: string
-            format: date
+        - $ref: '#/components/parameters/From'
+        - $ref: '#/components/parameters/To'
       responses:
         '200':
           description: Operation successful


### PR DESCRIPTION
* It is now possible to filter the data you want to download.
* Remove the default timeout for requests (30 seconds) to avoid aborting the download.
* Change translation key, because we now differ between monitoring and data tab.

Depending on: https://github.com/MORE-Platform/more-studymanager-frontend/pull/500