### PR TITLE
#361 Fix issue with incorrect elastic query conditions

### DIFF
--- a/studymanager-intervention/src/main/java/io/redlink/more/studymanager/component/trigger/datacheck/DataPointQuery.java
+++ b/studymanager-intervention/src/main/java/io/redlink/more/studymanager/component/trigger/datacheck/DataPointQuery.java
@@ -47,7 +47,7 @@ public class DataPointQuery {
         if("=".equals(operator) || "==".equals(operator)) {
             return "data_" + observationProperty + ":" + getSanitizedPropertyValue();
         } else if("!=".equals(operator)) {
-            return "!(data_" + observationProperty + ":" + getSanitizedPropertyValue() + ")";
+            return "NOT data_" + observationProperty + ":" + getSanitizedPropertyValue();
         } else if("<".equals(operator) || ">".equals(operator) || "<=".equals(operator) || ">=".equals(operator)) {
             return "data_" + observationProperty + ":" + operator + propertyValue;
         } else {

--- a/studymanager-intervention/src/main/java/io/redlink/more/studymanager/component/trigger/datacheck/QueryObject.java
+++ b/studymanager-intervention/src/main/java/io/redlink/more/studymanager/component/trigger/datacheck/QueryObject.java
@@ -34,7 +34,7 @@ public class QueryObject {
     public Set<DataPointQuery> parameter;
 
     public String toQueryString() {
-        return "(" + parameter.stream().map(DataPointQuery::toQueryString).collect(Collectors.joining(" AND ")) + ")";
+        return parameter.stream().map(DataPointQuery::toQueryString).collect(Collectors.joining(" AND "));
     }
 
 }

--- a/studymanager-intervention/src/main/java/io/redlink/more/studymanager/component/trigger/datacheck/ScheduledDatacheckTriggerProperties.java
+++ b/studymanager-intervention/src/main/java/io/redlink/more/studymanager/component/trigger/datacheck/ScheduledDatacheckTriggerProperties.java
@@ -11,6 +11,7 @@ package io.redlink.more.studymanager.component.trigger.datacheck;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.redlink.more.studymanager.core.properties.TriggerProperties;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -24,7 +25,7 @@ public class ScheduledDatacheckTriggerProperties extends TriggerProperties {
         return Optional.ofNullable(this.getString("cronSchedule"));
     }
 
-    public Optional<Set<QueryObject>> getQueryObject() {return this.getObject("queryObject", new TypeReference<>() {});}
+    public Optional<List<QueryObject>> getQueryObject() {return this.getObject("queryObject", new TypeReference<>() {});}
 
     public Optional<Long> getWindow() {
         return Optional.ofNullable(this.getLong("window"));


### PR DESCRIPTION
* Change Set to List, to ensure a correct order which is crucial for the query conditions, because a Set does not guarantees any ordering.
* In ElasticSearch Query Strings NOT is the preferred variant and used instead of ! to express negations.
* Removed redundant parentheses for cleaner query expressions.

The conditions were incorrect structured, depending on the random order provided by a Set Object.
If we have the following condition configured (trigger): A OR B OR C,
the query which were build, could be something like this: B OR C A OR (yes in this order), which leads to a invalid query (syntax) and therefore the trigger was not executed correctly.
Now the query is build correctly and multiple configured trigger conditions should work as intended.