### PR TITLE
#287 fix wrong labels

### DIFF
--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ConfigurationApiV1Controller.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ConfigurationApiV1Controller.java
@@ -36,10 +36,10 @@ public class ConfigurationApiV1Controller implements ConfigurationApi {
         return ResponseEntity.ok(
                 new BuildInfoDTO(
                         "null",
-                        Instant.MIN
+                        Instant.EPOCH
                 )
                         .branch("undefined")
-                        .rev("*dirty")
+                        .rev("unknown")
         );
     }
 

--- a/studymanager/src/main/java/io/redlink/more/studymanager/service/ElasticDataService.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/service/ElasticDataService.java
@@ -219,7 +219,7 @@ public class ElasticDataService {
                     .missing(NO_GROUP_KEY)
             );
             case TERM_FIELD -> a.terms(tf -> tf.field("data_%s.keyword".formatted(operation.field()))
-                    .minDocCount(0)
+                    .minDocCount(1)
             );
         };
     }


### PR DESCRIPTION
* If a second questionnaire is available, it will merge other possible answer options into the chart labels. Now this is not the case anymore (fixed)
* Now all other possible answer option for a specific questionnaire is added to the data view data later on.
* Fix invalid date format for build info