### PR TITLE
More 360 Fix encoded query param assignment for registration token

### DIFF
--- a/studymanager/src/main/java/io/redlink/more/studymanager/properties/GatewayProperties.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/properties/GatewayProperties.java
@@ -9,10 +9,10 @@
 package io.redlink.more.studymanager.properties;
 
 import io.redlink.more.studymanager.model.Participant;
+import java.net.URI;
+import java.util.Map;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.web.util.UriComponentsBuilder;
-
-import java.net.URI;
 
 @ConfigurationProperties(prefix = "more.gateway")
 public record GatewayProperties(String baseUrl) {
@@ -21,7 +21,7 @@ public record GatewayProperties(String baseUrl) {
 
         return UriComponentsBuilder.fromUriString(baseUrl)
                 .pathSegment("api", "v1", "signup")
-                .queryParam("token", participant.getRegistrationToken())
-                .build("token");
+                .queryParam("token", "{token}")
+                .build(Map.of("token", participant.getRegistrationToken()));
     }
 }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/properties/GatewayProperties.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/properties/GatewayProperties.java
@@ -21,7 +21,7 @@ public record GatewayProperties(String baseUrl) {
 
         return UriComponentsBuilder.fromUriString(baseUrl)
                 .pathSegment("api", "v1", "signup")
-                .queryParam("token", "{token}")
-                .build("token", participant.getRegistrationToken());
+                .queryParam("token", participant.getRegistrationToken())
+                .build("token");
     }
 }

--- a/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/ParticipantControllerTest.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/ParticipantControllerTest.java
@@ -16,9 +16,6 @@ import io.redlink.more.studymanager.model.PlatformRole;
 import io.redlink.more.studymanager.properties.GatewayProperties;
 import io.redlink.more.studymanager.service.OAuth2AuthenticationService;
 import io.redlink.more.studymanager.service.ParticipantService;
-import java.time.Instant;
-import java.util.EnumSet;
-import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,11 +28,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.Instant;
+import java.util.EnumSet;
+import java.util.UUID;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -44,6 +43,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest({ParticipantsApiV1Controller.class})
 @AutoConfigureMockMvc(addFilters = false)
 class ParticipantControllerTest {
+    public static final String SIGNUP_URL = "https://example.com";
+
     @MockBean
     ParticipantService participantService;
     @MockBean
@@ -60,7 +61,6 @@ class ParticipantControllerTest {
 
     @TestConfiguration
     static class GatewayPropertiesConfigurationTest {
-        public static final String SIGNUP_URL = "https://example.com";
 
         @Bean
         GatewayProperties gatewayProperties() {
@@ -207,7 +207,7 @@ class ParticipantControllerTest {
                 .andExpect(jsonPath("$.studyGroupId").value(participantRequest.getStudyGroupId()))
                 .andExpect(jsonPath("$.modified").exists())
                 .andExpect(jsonPath("$.created").exists())
-                .andExpect(jsonPath("$.registrationUrl").exists());
+                .andExpect(jsonPath("$.registrationUrl").value(SIGNUP_URL + "/api/v1/signup?token=" + token));
     }
 
 

--- a/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/ParticipantControllerTest.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/ParticipantControllerTest.java
@@ -16,6 +16,13 @@ import io.redlink.more.studymanager.model.PlatformRole;
 import io.redlink.more.studymanager.properties.GatewayProperties;
 import io.redlink.more.studymanager.service.OAuth2AuthenticationService;
 import io.redlink.more.studymanager.service.ParticipantService;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.EnumSet;
+import java.util.Random;
+import java.util.UUID;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,13 +35,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.time.Instant;
-import java.util.EnumSet;
-import java.util.UUID;
-
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -179,68 +186,69 @@ class ParticipantControllerTest {
     @Test
     @DisplayName("The created signup URI of an participant with a token is correct")
     void testRegistrationUri() throws Exception {
-        String token = "laskdfjlkasdfj1z239i1uf";
-        when(participantService.getParticipant(1L, 1)).thenAnswer(invocationOnMock ->
+        final Random rnd = new Random();
+        final long studyId = rnd.nextLong();
+        final int participantId = rnd.nextInt();
+        final int studyGroupId = rnd.nextInt();
+        final String token = RandomStringUtils.randomAlphanumeric(3)
+                + "&" + RandomStringUtils.randomAlphanumeric(3)
+                + "?" + RandomStringUtils.randomAlphanumeric(3);
+
+        when(participantService.getParticipant(anyLong(), anyInt())).thenAnswer(invocationOnMock ->
                 new Participant()
                         .setStudyId(invocationOnMock.getArgument(0, Long.class))
                         .setParticipantId(invocationOnMock.getArgument(1, Integer.class))
-                        .setStudyGroupId(1)
+                        .setStudyGroupId(studyGroupId)
                         .setStatus(Participant.Status.NEW)
                         .setAlias("person x")
                         .setCreated(Instant.ofEpochMilli(0))
                         .setModified(Instant.ofEpochMilli(0))
                         .setRegistrationToken(token));
 
-        ParticipantDTO participantRequest = new ParticipantDTO()
-                .studyId(1L)
-                .participantId(1)
-                .studyGroupId(1)
-                .alias("person x");
-
-        mvc.perform(get("/api/v1/studies/1/participants/1")
-                        .content(mapper.writeValueAsString(participantRequest))
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(get("/api/v1/studies/{study}/participants/{participant}", studyId, participantId))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.studyId").value(participantRequest.getStudyId()))
-                .andExpect(jsonPath("$.participantId").value(participantRequest.getParticipantId()))
-                .andExpect(jsonPath("$.studyGroupId").value(participantRequest.getStudyGroupId()))
+                .andExpect(jsonPath("$.studyId").value(studyId))
+                .andExpect(jsonPath("$.participantId").value(participantId))
+                .andExpect(jsonPath("$.studyGroupId").value(studyGroupId))
                 .andExpect(jsonPath("$.modified").exists())
                 .andExpect(jsonPath("$.created").exists())
-                .andExpect(jsonPath("$.registrationUrl").value(SIGNUP_URL + "/api/v1/signup?token=" + token));
+                .andExpect(jsonPath("$.registrationToken").value(token))
+                .andExpect(jsonPath("$.registrationUrl")
+                        .value(SIGNUP_URL + "/api/v1/signup?token=" + URLEncoder.encode(token, StandardCharsets.UTF_8)));
+
     }
 
 
     @Test
     @DisplayName("The created signup URI of an participant without a token is null")
     void testNoRegistrationUri() throws Exception {
-        when(participantService.getParticipant(1L, 1)).thenAnswer(invocationOnMock ->
+        final Random rnd = new Random();
+        final long studyId = rnd.nextLong();
+        final int participantId = rnd.nextInt();
+        final int studyGroupId = rnd.nextInt();
+
+
+        when(participantService.getParticipant(any(), anyInt())).thenAnswer(invocationOnMock ->
                 new Participant()
                         .setStudyId(invocationOnMock.getArgument(0, Long.class))
                         .setParticipantId(invocationOnMock.getArgument(1, Integer.class))
-                        .setStudyGroupId(1)
+                        .setStudyGroupId(studyGroupId)
                         .setStatus(Participant.Status.NEW)
                         .setAlias("person x")
                         .setCreated(Instant.ofEpochMilli(0))
                         .setModified(Instant.ofEpochMilli(0))
                         .setRegistrationToken(null));
 
-        ParticipantDTO participantRequest = new ParticipantDTO()
-                .studyId(1L)
-                .participantId(1)
-                .studyGroupId(1)
-                .alias("person x");
-
-        mvc.perform(get("/api/v1/studies/1/participants/1")
-                        .content(mapper.writeValueAsString(participantRequest))
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(get("/api/v1/studies/{study}/participants/{participant}", studyId, participantId))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.studyId").value(participantRequest.getStudyId()))
-                .andExpect(jsonPath("$.participantId").value(participantRequest.getParticipantId()))
-                .andExpect(jsonPath("$.studyGroupId").value(participantRequest.getStudyGroupId()))
+                .andExpect(jsonPath("$.studyId").value(studyId))
+                .andExpect(jsonPath("$.participantId").value(participantId))
+                .andExpect(jsonPath("$.studyGroupId").value(studyGroupId))
                 .andExpect(jsonPath("$.modified").exists())
                 .andExpect(jsonPath("$.created").exists())
+                .andExpect(jsonPath("$.registrationToken").isEmpty())
                 .andExpect(jsonPath("$.registrationUrl").isEmpty());
     }
 }


### PR DESCRIPTION
Instead of delivering `signup?token=token` now `signup?token=sdfz32erjnfsd` is sent