### PR TITLE
Implements an AuditLog for the StudiyManager Backend

### DIFF
--- a/studymanager/pom.xml
+++ b/studymanager/pom.xml
@@ -91,6 +91,17 @@
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
+            <version>2.2</version>
+        </dependency>
+
+        <!-- Spring AOP (for auditLogs) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
 
         <!-- spring's support for quartz -->
         <dependency>

--- a/studymanager/pom.xml
+++ b/studymanager/pom.xml
@@ -91,11 +91,6 @@
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
-            <version>2.2</version>
-        </dependency>
 
         <!-- Spring AOP (for auditLogs) -->
         <dependency>

--- a/studymanager/src/main/java/io/redlink/more/studymanager/audit/AuditAspect.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/audit/AuditAspect.java
@@ -1,0 +1,139 @@
+package io.redlink.more.studymanager.audit;
+
+import io.redlink.more.studymanager.api.v1.model.StudyDTO;
+import io.redlink.more.studymanager.model.AuthenticatedUser;
+import io.redlink.more.studymanager.model.PlatformRole;
+import io.redlink.more.studymanager.model.Study;
+import io.redlink.more.studymanager.model.audit.AuditLog;
+import io.redlink.more.studymanager.properties.AuditProperties;
+import io.redlink.more.studymanager.service.AuditService;
+import io.redlink.more.studymanager.service.OAuth2AuthenticationService;
+import io.redlink.more.studymanager.utils.MapperUtils;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.CodeSignature;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+@Aspect
+@Component
+public class AuditAspect {
+    private final AuditProperties auditProperties;
+    private final AuditService auditService;
+    private final OAuth2AuthenticationService authService;
+
+    public AuditAspect(
+            AuditProperties auditProperties,
+            AuditService auditService,
+            OAuth2AuthenticationService authService) {
+        this.auditService = auditService;
+        this.authService = authService;
+        this.auditProperties = auditProperties;
+    }
+        @AfterThrowing(pointcut = "@annotation(Audited)", throwing = "e")
+        public void recordException(JoinPoint joinPoint, Throwable e){
+            auditService.record(toAuditLog(authService.getCurrentUser(), joinPoint, null, e));
+        }
+        @AfterReturning(pointcut = "@annotation(Audited)", returning = "returnValue")
+        public void recordActivity(JoinPoint joinPoint, Object returnValue) throws Throwable {
+            auditService.record(toAuditLog(authService.getCurrentUser(), joinPoint, returnValue, null));
+        }
+
+    private AuditLog toAuditLog(AuthenticatedUser user, JoinPoint joinPoint, Object returnValue, Throwable e) {
+        Instant timestamp = Instant.now();
+        String action = joinPoint.getSignature().toLongString();
+        CodeSignature methodSignature = (CodeSignature) joinPoint.getSignature();
+        //we need to search for the user and study
+        Map<String, Object> parameters = new HashMap<>();
+        int studyParamIdx = -1;
+        for(int i=0; i < methodSignature.getParameterNames().length; i++){
+            var paramName = methodSignature.getParameterNames()[i];
+            var paramType = methodSignature.getParameterTypes()[i];
+            if(studyParamIdx < 0 &&
+                    paramName.toLowerCase(Locale.ROOT).startsWith("study") &&
+                    paramType.isAssignableFrom(Long.class)){
+                studyParamIdx = i;
+            } else if(MapperUtils.isSerializable(joinPoint.getArgs()[i], auditProperties.detailsByteLimit())){
+                parameters.put("param_" + paramName, joinPoint.getArgs()[i]);
+            } else {
+                parameters.put("param_" + paramName, "<not-serializable>");
+            }
+        }
+        final Long studyId;
+        if(studyParamIdx < 0){
+            studyId = getStudyIdFromResponse(returnValue);
+        } else {
+            studyId = (Long) joinPoint.getArgs()[studyParamIdx];
+        }
+        if(studyId == null){
+            throw new IllegalStateException(String.format("Unable to create AuditLog for Action '%s' as studyId parameter could not be retrieved from the signature", action));
+        }
+
+        AuditLog auditLog = new AuditLog(user.id(), studyId, action, timestamp)
+                .setActionState(getActionState(returnValue, e));
+        //finally set some additional information (if available)
+        auditLog.getDetails().putAll(parameters);
+        auditLog.getDetails().put("user_roles", user.roles().stream().map(PlatformRole::name).toList());
+        if(e != null){
+            auditLog.getDetails().put("exception", e.getClass().getName());
+        }
+        if(returnValue instanceof ResponseEntity re){
+            auditLog.getDetails().put("http_status", re.getStatusCode().value());
+            if(re.getHeaders().getContentType() != null) {
+                auditLog.getDetails().put("header_content-type", re.getHeaders().getContentType().toString());
+            }
+            if(re.getHeaders().getLocation() != null) {
+                auditLog.getDetails().put("header_location", re.getHeaders().getLocation().toString());
+            }
+        }
+        return auditLog;
+    }
+
+    /**
+     * Tries to get the StudyId from the method response ({@link JoinPoint#getTarget()}). This is usefull e.g. for
+     * a method the imports a study to the system
+     * @param target the {@link JoinPoint#getTarget()}
+     * @return the StudyId or <code>null</code> if not successfull
+     */
+    private static Long getStudyIdFromResponse(Object target) {
+        Object response = (target instanceof ResponseEntity re) && re.getStatusCode().is2xxSuccessful() ? re.getBody() : target;
+        if(response instanceof StudyDTO studyDTO){
+            return studyDTO.getStudyId();
+        } else if(response instanceof Study study){
+            return study.getStudyId();
+        } else {
+            return null;
+        }
+    }
+
+    private static AuditLog.ActionState getActionState(Object target, Throwable e) {
+        final AuditLog.ActionState state;
+        if(e != null){
+            state = AuditLog.ActionState.error;
+        } else if(target instanceof ResponseEntity re){
+            //special support for Methods that return ResponseEntity
+            if(re.getStatusCode().is2xxSuccessful()){
+                state = AuditLog.ActionState.success;
+            } else if(re.getStatusCode().is3xxRedirection()){
+                state = AuditLog.ActionState.redirect;
+            } else if( re.getStatusCode().is4xxClientError() || re.getStatusCode().is5xxServerError()){
+                state = AuditLog.ActionState.error;
+            } else {
+                state = AuditLog.ActionState.unknown;
+            }
+        } else if(target == null){
+            state = AuditLog.ActionState.error;
+        } else {
+            state = AuditLog.ActionState.success;
+        }
+        return state;
+    }
+
+}

--- a/studymanager/src/main/java/io/redlink/more/studymanager/audit/Audited.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/audit/Audited.java
@@ -1,0 +1,16 @@
+package io.redlink.more.studymanager.audit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation used for AOP based audit logging as Pointcut
+ *
+ * All Method calls annotated with the annotation are logged in the audit log
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Audited {
+}

--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/CalendarApiV1Controller.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/CalendarApiV1Controller.java
@@ -10,6 +10,7 @@ package io.redlink.more.studymanager.controller.studymanager;
 
 import io.redlink.more.studymanager.api.v1.model.StudyTimelineDTO;
 import io.redlink.more.studymanager.api.v1.webservices.CalendarApi;
+import io.redlink.more.studymanager.audit.Audited;
 import io.redlink.more.studymanager.controller.RequiresStudyRole;
 import io.redlink.more.studymanager.model.StudyRole;
 import io.redlink.more.studymanager.model.transformer.TimelineTransformer;
@@ -38,6 +39,7 @@ public class CalendarApiV1Controller implements CalendarApi {
     }
 
     @Override
+    @Audited
     public ResponseEntity<String> getStudyCalendar(Long studyId) {
         return ResponseEntity
                 .status(301)
@@ -47,6 +49,7 @@ public class CalendarApiV1Controller implements CalendarApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<StudyTimelineDTO> getStudyTimeline(Long studyId, Integer participant, Integer studyGroup, Instant referenceDate, LocalDate from, LocalDate to) {
         return ResponseEntity.ok(
                 TimelineTransformer.toStudyTimelineDTO(

--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/CollaboratorsApiV1Controller.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/CollaboratorsApiV1Controller.java
@@ -12,6 +12,7 @@ import io.redlink.more.studymanager.api.v1.model.CollaboratorDTO;
 import io.redlink.more.studymanager.api.v1.model.CollaboratorDetailsDTO;
 import io.redlink.more.studymanager.api.v1.model.StudyRoleDTO;
 import io.redlink.more.studymanager.api.v1.webservices.CollaboratorsApi;
+import io.redlink.more.studymanager.audit.Audited;
 import io.redlink.more.studymanager.controller.RequiresStudyRole;
 import io.redlink.more.studymanager.model.StudyRole;
 import io.redlink.more.studymanager.model.transformer.RoleTransformer;
@@ -41,6 +42,7 @@ public class CollaboratorsApiV1Controller implements CollaboratorsApi {
 
     @Override
     @RequiresStudyRole
+    @Audited
     public ResponseEntity<List<CollaboratorDTO>> listStudyCollaborators(Long studyId) {
         return ResponseEntity.ok(
                 studyService.getACL(studyId).entrySet().stream()
@@ -51,27 +53,30 @@ public class CollaboratorsApiV1Controller implements CollaboratorsApi {
 
     @Override
     @RequiresStudyRole(StudyRole.STUDY_ADMIN)
-    public ResponseEntity<Void> clearStudyCollaboratorRoles(Long studyId, String uid) {
+    @Audited
+    public ResponseEntity<Void> clearStudyCollaboratorRoles(Long studyId, String userId) {
         final var currentUser = authService.getCurrentUser();
-        studyService.setRolesForStudy(studyId, uid, EnumSet.noneOf(StudyRole.class), currentUser);
+        studyService.setRolesForStudy(studyId, userId, EnumSet.noneOf(StudyRole.class), currentUser);
         return ResponseEntity.noContent().build();
     }
 
     @Override
     @RequiresStudyRole
-    public ResponseEntity<CollaboratorDetailsDTO> getStudyCollaboratorRoles(Long studyId, String uid) {
+    @Audited
+    public ResponseEntity<CollaboratorDetailsDTO> getStudyCollaboratorRoles(Long studyId, String userId) {
         return ResponseEntity.of(
-                studyService.getRolesForStudy(studyId, uid)
+                studyService.getRolesForStudy(studyId, userId)
                         .map(UserInfoTransformer::toCollaboratorDetailsDTO)
         );
     }
 
     @Override
     @RequiresStudyRole(StudyRole.STUDY_ADMIN)
-    public ResponseEntity<CollaboratorDetailsDTO> setStudyCollaboratorRoles(Long studyId, String uid, Set<StudyRoleDTO> studyRoleDTO) {
+    @Audited
+    public ResponseEntity<CollaboratorDetailsDTO> setStudyCollaboratorRoles(Long studyId, String userId, Set<StudyRoleDTO> studyRoleDTO) {
         final var currentUser = authService.getCurrentUser();
         return ResponseEntity.of(
-                studyService.setRolesForStudy(studyId, uid, RoleTransformer.toStudyRoles(studyRoleDTO), currentUser)
+                studyService.setRolesForStudy(studyId, userId, RoleTransformer.toStudyRoles(studyRoleDTO), currentUser)
                         .map(UserInfoTransformer::toCollaboratorDetailsDTO)
         );
     }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/DataApiV1Controller.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/DataApiV1Controller.java
@@ -13,6 +13,7 @@ import io.redlink.more.studymanager.api.v1.model.ObservationDataViewDTO;
 import io.redlink.more.studymanager.api.v1.model.ObservationDataViewDataDTO;
 import io.redlink.more.studymanager.api.v1.model.ParticipationDataDTO;
 import io.redlink.more.studymanager.api.v1.webservices.DataApi;
+import io.redlink.more.studymanager.audit.Audited;
 import io.redlink.more.studymanager.controller.RequiresStudyRole;
 import io.redlink.more.studymanager.model.StudyRole;
 import io.redlink.more.studymanager.model.transformer.StudyDataTransformer;
@@ -35,6 +36,7 @@ public class DataApiV1Controller implements DataApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_VIEWER})
+    @Audited
     public ResponseEntity<List<DataPointDTO>> getDataPoints(
             Long studyId, Integer size, Integer observationId, Integer participantId, Instant date
     ) {
@@ -45,6 +47,7 @@ public class DataApiV1Controller implements DataApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_VIEWER})
+    @Audited
     public ResponseEntity<List<ParticipationDataDTO>> getParticipationData(Long studyId){
         return ResponseEntity.ok().body(
                 dataProcessingService.getParticipationData(studyId).stream()
@@ -55,6 +58,7 @@ public class DataApiV1Controller implements DataApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_VIEWER})
+    @Audited
     public ResponseEntity<ObservationDataViewDataDTO> getObservationViewData(Long studyId, Integer observationId, String viewName, Integer studyGroupId, Integer participantId, Instant from, Instant to) {
         return ResponseEntity.ok().body(
                 StudyDataTransformer.toObservationDataViewDataDTO(
@@ -65,6 +69,7 @@ public class DataApiV1Controller implements DataApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_VIEWER})
+    @Audited
     public ResponseEntity<List<ObservationDataViewDTO>> listObservationViews(Long studyId, Integer observationId) {
         return ResponseEntity.ok().body(
                 Arrays.stream(dataProcessingService.listDataViews(studyId, observationId))

--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ImportExportApiV1Controller.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ImportExportApiV1Controller.java
@@ -12,6 +12,7 @@ import io.redlink.more.studymanager.api.v1.model.GenerateDownloadToken200Respons
 import io.redlink.more.studymanager.api.v1.model.StudyDTO;
 import io.redlink.more.studymanager.api.v1.model.StudyImportExportDTO;
 import io.redlink.more.studymanager.api.v1.webservices.ImportExportApi;
+import io.redlink.more.studymanager.audit.Audited;
 import io.redlink.more.studymanager.controller.RequiresStudyRole;
 import io.redlink.more.studymanager.model.DownloadToken;
 import io.redlink.more.studymanager.model.StudyRole;
@@ -61,6 +62,7 @@ public class ImportExportApiV1Controller implements ImportExportApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<Resource> exportParticipants(Long studyId) {
         final var currentUser = authService.getCurrentUser();
         return ResponseEntity.ok(
@@ -70,6 +72,7 @@ public class ImportExportApiV1Controller implements ImportExportApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<Void> importParticipants(Long studyId, MultipartFile file) {
         try {
             service.importParticipants(studyId, file.getInputStream());
@@ -82,6 +85,7 @@ public class ImportExportApiV1Controller implements ImportExportApi {
 
     @Override
     @RequiresStudyRole(StudyRole.STUDY_ADMIN)
+    @Audited
     public ResponseEntity<StudyImportExportDTO> exportStudy(Long studyId) {
         final var currentUser = authService.getCurrentUser();
         return ResponseEntity.ok(
@@ -93,6 +97,8 @@ public class ImportExportApiV1Controller implements ImportExportApi {
     }
 
     @Override
+    @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<StreamingResponseBody> exportStudyData(Long studyId, String token, List<Integer> studyGroupId, List<Integer> participantId, List<Integer> observationId, Instant from, Instant to) {
         Optional<DownloadToken> dt = tokenRepository.getToken(token).filter(t -> t.getStudyId().equals(studyId));
 
@@ -118,6 +124,7 @@ public class ImportExportApiV1Controller implements ImportExportApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<GenerateDownloadToken200ResponseDTO> generateDownloadToken(Long studyId, List<Integer> studyGroupId, List<Integer> participantId, List<Integer> observationId, Instant from, Instant to) {
         var token = tokenRepository.createToken(studyId).getToken();
         var uri = ServletUriComponentsBuilder.fromCurrentRequest().pathSegment(token).build(true).toUri();
@@ -126,6 +133,7 @@ public class ImportExportApiV1Controller implements ImportExportApi {
     }
 
     @Override
+    @Audited
     public ResponseEntity<StudyDTO> importStudy(MultipartFile file) {
         try {
             final var currentUser = authService.getCurrentUser();

--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/InterventionsApiV1Controller.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/InterventionsApiV1Controller.java
@@ -12,6 +12,7 @@ import io.redlink.more.studymanager.api.v1.model.ActionDTO;
 import io.redlink.more.studymanager.api.v1.model.InterventionDTO;
 import io.redlink.more.studymanager.api.v1.model.TriggerDTO;
 import io.redlink.more.studymanager.api.v1.webservices.InterventionsApi;
+import io.redlink.more.studymanager.audit.Audited;
 import io.redlink.more.studymanager.controller.RequiresStudyRole;
 import io.redlink.more.studymanager.model.StudyRole;
 import io.redlink.more.studymanager.model.transformer.ActionTransformer;
@@ -39,6 +40,7 @@ public class InterventionsApiV1Controller implements InterventionsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<InterventionDTO> addIntervention(Long studyId, InterventionDTO interventionDTO) {
         return ResponseEntity.status(HttpStatus.CREATED).body(
                 InterventionTransformer.toInterventionDTO_V1(
@@ -51,6 +53,7 @@ public class InterventionsApiV1Controller implements InterventionsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<ActionDTO> createAction(Long studyId, Integer interventionId, ActionDTO actionDTO) {
         return ResponseEntity.status(HttpStatus.CREATED).body(
                 ActionTransformer.toActionDTO_V1(
@@ -64,6 +67,7 @@ public class InterventionsApiV1Controller implements InterventionsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<Void> deleteAction(Long studyId, Integer interventionId, Integer actionId) {
         service.deleteAction(studyId, interventionId, actionId);
         return ResponseEntity.noContent().build();
@@ -71,6 +75,7 @@ public class InterventionsApiV1Controller implements InterventionsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<Void> deleteIntervention(Long studyId, Integer interventionId) {
         service.deleteIntervention(studyId, interventionId);
         return ResponseEntity.noContent().build();
@@ -78,6 +83,7 @@ public class InterventionsApiV1Controller implements InterventionsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<ActionDTO> getAction(Long studyId, Integer interventionId, Integer actionId) {
         return ResponseEntity.ok(ActionTransformer.toActionDTO_V1(
                 service.getActionByIds(studyId, interventionId, actionId)
@@ -86,6 +92,7 @@ public class InterventionsApiV1Controller implements InterventionsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<InterventionDTO> getIntervention(Long studyId, Integer interventionId) {
         return ResponseEntity.status(HttpStatus.OK).body(InterventionTransformer.toInterventionDTO_V1(
                 service.getIntervention(studyId, interventionId)
@@ -94,6 +101,7 @@ public class InterventionsApiV1Controller implements InterventionsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<TriggerDTO> getTrigger(Long studyId, Integer interventionId) {
         return ResponseEntity.ok(TriggerTransformer.toTriggerDTO_V1(
                 service.getTriggerByIds(studyId, interventionId)
@@ -102,6 +110,7 @@ public class InterventionsApiV1Controller implements InterventionsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<List<ActionDTO>> listActions(Long studyId, Integer interventionId) {
         return ResponseEntity.ok(service.listActions(studyId, interventionId).stream()
                 .map(ActionTransformer::toActionDTO_V1)
@@ -111,6 +120,7 @@ public class InterventionsApiV1Controller implements InterventionsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<List<InterventionDTO>> listInterventions(Long studyId) {
         return ResponseEntity.ok(
                 service.listInterventions(studyId).stream()
@@ -121,6 +131,7 @@ public class InterventionsApiV1Controller implements InterventionsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<ActionDTO> updateAction(Long studyId, Integer interventionId, Integer actionId, ActionDTO actionDTO) {
         return ResponseEntity.ok(ActionTransformer.toActionDTO_V1(
                 service.updateAction(
@@ -132,6 +143,7 @@ public class InterventionsApiV1Controller implements InterventionsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<InterventionDTO> updateIntervention(Long studyId, Integer interventionId, InterventionDTO interventionDTO) {
         return ResponseEntity.ok(
                 InterventionTransformer.toInterventionDTO_V1(
@@ -144,6 +156,7 @@ public class InterventionsApiV1Controller implements InterventionsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<TriggerDTO> updateTrigger(Long studyId, Integer interventionId, TriggerDTO triggerDTO) {
         return ResponseEntity.ok(
                 TriggerTransformer.toTriggerDTO_V1(

--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/LimeSurveySidecarController.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/LimeSurveySidecarController.java
@@ -8,6 +8,7 @@
  */
 package io.redlink.more.studymanager.controller.studymanager;
 
+import io.redlink.more.studymanager.audit.Audited;
 import io.redlink.more.studymanager.component.observation.lime.LimeSurveyObservationFactory;
 import io.redlink.more.studymanager.sdk.MoreSDK;
 import io.redlink.more.studymanager.service.ObservationService;
@@ -34,7 +35,7 @@ public class LimeSurveySidecarController {
     }
 
     /**
-     * This is a temporary solution that should actually run as a sidecard and use an client credentials flow to access the limesurvey component api
+     * This is a temporary solution that should actually run as a sidecard and use a client credentials flow to access the limesurvey component api
      * @return a html response
      */
     @RequestMapping(
@@ -42,6 +43,7 @@ public class LimeSurveySidecarController {
             value = "/components/observation/lime-survey-observation/end.html",
             produces = { "text/html" }
     )
+    @Audited
     public ResponseEntity<String> getLimeSurveyEndPageAndWriteResult(
             @RequestParam("studyId") Long studyId,
             @RequestParam("observationId") Integer observationId,

--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ObservationsApiV1Controller.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ObservationsApiV1Controller.java
@@ -11,6 +11,7 @@ package io.redlink.more.studymanager.controller.studymanager;
 import io.redlink.more.studymanager.api.v1.model.EndpointTokenDTO;
 import io.redlink.more.studymanager.api.v1.model.ObservationDTO;
 import io.redlink.more.studymanager.api.v1.webservices.ObservationsApi;
+import io.redlink.more.studymanager.audit.Audited;
 import io.redlink.more.studymanager.controller.RequiresStudyRole;
 import io.redlink.more.studymanager.exception.BadRequestException;
 import io.redlink.more.studymanager.model.EndpointToken;
@@ -44,6 +45,7 @@ public class ObservationsApiV1Controller implements ObservationsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<ObservationDTO> addObservation(Long studyId, ObservationDTO observationDTO) {
         Observation observation = service.addObservation(
                 ObservationTransformer.fromObservationDTO_V1(observationDTO.studyId(studyId))
@@ -55,6 +57,7 @@ public class ObservationsApiV1Controller implements ObservationsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<Void> deleteObservation(Long studyId, Integer observationId) {
         service.deleteObservation(studyId, observationId);
         return ResponseEntity.noContent().build();
@@ -62,6 +65,7 @@ public class ObservationsApiV1Controller implements ObservationsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<List<ObservationDTO>> listObservations(Long studyId) {
         return ResponseEntity.ok().body(
                 service.listObservations(studyId).stream()
@@ -72,6 +76,7 @@ public class ObservationsApiV1Controller implements ObservationsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<ObservationDTO> updateObservation(Long studyId, Integer observationId, ObservationDTO observationDTO) {
         Observation observation = service.updateObservation(
                 ObservationTransformer.fromObservationDTO_V1(observationDTO.studyId(studyId).observationId(observationId))
@@ -83,6 +88,7 @@ public class ObservationsApiV1Controller implements ObservationsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<EndpointTokenDTO> createToken(Long studyId, Integer observationId, EndpointTokenDTO token) {
         if(token.getTokenLabel().isBlank()) { return ResponseEntity.status(HttpStatus.BAD_REQUEST).build(); }
 
@@ -100,6 +106,7 @@ public class ObservationsApiV1Controller implements ObservationsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<EndpointTokenDTO> updateTokenLabel(Long studyId, Integer observationId, Integer tokenId, EndpointTokenDTO endpointToken) {
         Optional<EndpointToken> token = integrationService.updateToken(studyId, observationId, tokenId, endpointToken.getTokenLabel());
 
@@ -110,6 +117,7 @@ public class ObservationsApiV1Controller implements ObservationsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<EndpointTokenDTO> getToken(Long studyId, Integer observationId, Integer tokenId) {
 
         Optional<EndpointToken> token = integrationService.getToken(studyId, observationId, tokenId);
@@ -125,6 +133,7 @@ public class ObservationsApiV1Controller implements ObservationsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<List<EndpointTokenDTO>> getTokens(Long studyId, Integer observationId) {
         return ResponseEntity.ok().body(
                 EndpointTokenTransformer.toEndpointTokensDTO(
@@ -135,6 +144,7 @@ public class ObservationsApiV1Controller implements ObservationsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<Void> deleteToken(Long studyId, Integer observationId, Integer tokenId) {
         integrationService.deleteToken(studyId, observationId, tokenId);
         return ResponseEntity.noContent().build();

--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ParticipantsApiV1Controller.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ParticipantsApiV1Controller.java
@@ -10,6 +10,7 @@ package io.redlink.more.studymanager.controller.studymanager;
 
 import io.redlink.more.studymanager.api.v1.model.ParticipantDTO;
 import io.redlink.more.studymanager.api.v1.webservices.ParticipantsApi;
+import io.redlink.more.studymanager.audit.Audited;
 import io.redlink.more.studymanager.controller.RequiresStudyRole;
 import io.redlink.more.studymanager.exception.NotFoundException;
 import io.redlink.more.studymanager.model.Participant;
@@ -43,6 +44,7 @@ public class ParticipantsApiV1Controller implements ParticipantsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<List<ParticipantDTO>> createParticipants(Long studyId, List<ParticipantDTO> participantDTO) {
         List<Participant> participants = participantDTO.stream()
                 .map(p -> p.studyId(studyId))
@@ -58,6 +60,7 @@ public class ParticipantsApiV1Controller implements ParticipantsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<List<ParticipantDTO>> updateParticipantList(Long studyId, List<ParticipantDTO> participantDTO) {
         if (participantDTO.stream().anyMatch(p -> p.getParticipantId() == null)) {
             throw new NotFoundException("Participant without id");
@@ -76,6 +79,7 @@ public class ParticipantsApiV1Controller implements ParticipantsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<Void> deleteParticipant(Long studyId, Integer participantId, Boolean includeData) {
         service.deleteParticipant(studyId, participantId, includeData);
         return ResponseEntity.noContent().build();
@@ -84,6 +88,7 @@ public class ParticipantsApiV1Controller implements ParticipantsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<ParticipantDTO> getParticipant(Long studyId, Integer participantId) {
         return ResponseEntity.ok(
                 toParticipantDTO(service.getParticipant(studyId, participantId))
@@ -92,6 +97,7 @@ public class ParticipantsApiV1Controller implements ParticipantsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<List<ParticipantDTO>> listParticipants(Long studyId) {
         return ResponseEntity.ok(
                 service.listParticipants(studyId).stream()
@@ -102,6 +108,7 @@ public class ParticipantsApiV1Controller implements ParticipantsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<ParticipantDTO> updateParticipant(Long studyId, Integer participantId, ParticipantDTO participantDTO) {
         Participant participant = service.updateParticipant(
                 ParticipantTransformer.fromParticipantDTO_V1((participantDTO.studyId(studyId)).participantId(participantId))

--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/StudyApiV1Controller.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/StudyApiV1Controller.java
@@ -11,6 +11,7 @@ package io.redlink.more.studymanager.controller.studymanager;
 import io.redlink.more.studymanager.api.v1.model.StatusChangeDTO;
 import io.redlink.more.studymanager.api.v1.model.StudyDTO;
 import io.redlink.more.studymanager.api.v1.webservices.StudiesApi;
+import io.redlink.more.studymanager.audit.Audited;
 import io.redlink.more.studymanager.controller.RequiresStudyRole;
 import io.redlink.more.studymanager.model.Study;
 import io.redlink.more.studymanager.model.StudyRole;
@@ -42,6 +43,7 @@ public class StudyApiV1Controller implements StudiesApi {
     }
 
     @Override
+    @Audited
     public ResponseEntity<StudyDTO> createStudy(StudyDTO studyDTO) {
         final var currentUser = authService.getCurrentUser();
         Study study = service.createStudy(StudyTransformer.fromStudyDTO_V1(studyDTO), currentUser);
@@ -51,7 +53,7 @@ public class StudyApiV1Controller implements StudiesApi {
         );
     }
 
-    @Override
+    @Override //FIXME: This method does not work with AuditLog as it has no single Study as context
     public ResponseEntity<List<StudyDTO>> listStudies() {
         final var currentUser = authService.getCurrentUser();
         return ResponseEntity.ok(
@@ -63,6 +65,7 @@ public class StudyApiV1Controller implements StudiesApi {
 
     @Override
     @RequiresStudyRole
+    @Audited
     public ResponseEntity<StudyDTO> getStudy(Long studyId) {
         final var currentUser = authService.getCurrentUser();
         return ResponseEntity.of(
@@ -73,6 +76,7 @@ public class StudyApiV1Controller implements StudiesApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<StudyDTO> updateStudy(Long studyId, StudyDTO studyDTO) {
         final var currentUser = authService.getCurrentUser();
         return ResponseEntity.of(
@@ -84,6 +88,7 @@ public class StudyApiV1Controller implements StudiesApi {
 
     @Override
     @RequiresStudyRole(StudyRole.STUDY_ADMIN)
+    @Audited
     public ResponseEntity<Void> deleteStudy(Long studyId) {
         service.deleteStudy(studyId);
         return ResponseEntity.noContent().build();
@@ -91,6 +96,7 @@ public class StudyApiV1Controller implements StudiesApi {
 
     @Override
     @RequiresStudyRole(StudyRole.STUDY_ADMIN)
+    @Audited
     public ResponseEntity<StudyDTO> setStatus(Long studyId, StatusChangeDTO statusChangeDTO) {
         final var currentUser = authService.getCurrentUser();
 

--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/StudyGroupApiV1Controller.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/StudyGroupApiV1Controller.java
@@ -10,6 +10,7 @@ package io.redlink.more.studymanager.controller.studymanager;
 
 import io.redlink.more.studymanager.api.v1.model.StudyGroupDTO;
 import io.redlink.more.studymanager.api.v1.webservices.StudyGroupsApi;
+import io.redlink.more.studymanager.audit.Audited;
 import io.redlink.more.studymanager.controller.RequiresStudyRole;
 import io.redlink.more.studymanager.model.StudyGroup;
 import io.redlink.more.studymanager.model.StudyRole;
@@ -40,6 +41,7 @@ public class StudyGroupApiV1Controller implements StudyGroupsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<StudyGroupDTO> createStudyGroup(Long studyId, StudyGroupDTO studyGroupDTO) {
         StudyGroup studyGroup = service.createStudyGroup(
                 StudyGroupTransformer.fromStudyGroupDTO_V1(studyGroupDTO)
@@ -52,6 +54,7 @@ public class StudyGroupApiV1Controller implements StudyGroupsApi {
 
     @Override
     @RequiresStudyRole
+    @Audited
     public ResponseEntity<List<StudyGroupDTO>> listStudyGroups(Long studyId) {
         return ResponseEntity.ok(
                 service.listStudyGroups(studyId).stream()
@@ -62,6 +65,7 @@ public class StudyGroupApiV1Controller implements StudyGroupsApi {
 
     @Override
     @RequiresStudyRole
+    @Audited
     public ResponseEntity<StudyGroupDTO> getStudyGroup(Long studyId, Integer studyGroupId) {
         return ResponseEntity.ok(
                 StudyGroupTransformer.toStudyGroupDTO_V1(service.getStudyGroup(studyId, studyGroupId))
@@ -70,6 +74,7 @@ public class StudyGroupApiV1Controller implements StudyGroupsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<StudyGroupDTO> updateStudyGroup(Long studyId, Integer studyGroupId, StudyGroupDTO studyGroupDTO) {
         return ResponseEntity.ok(
                 StudyGroupTransformer.toStudyGroupDTO_V1(
@@ -82,6 +87,7 @@ public class StudyGroupApiV1Controller implements StudyGroupsApi {
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
+    @Audited
     public ResponseEntity<Void> deleteStudyGroup(Long studyId, Integer studyGroupId) {
         service.deleteStudyGroup(studyId, studyGroupId);
         return ResponseEntity.noContent().build();

--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/UserApiV1Controller.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/UserApiV1Controller.java
@@ -84,7 +84,7 @@ public class UserApiV1Controller implements UsersApi {
         return null;
     }
 
-    @Override
+    @Override //FIXME: This Method does not work with AuditLog as it does not have a Study as context
     public ResponseEntity<UserSearchResultListDTO> findUsers(String q, Integer offset, Integer limit) {
         limit = Math.min(limit, 15);
         return ResponseEntity.ok(

--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/audit/AuditLog.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/audit/AuditLog.java
@@ -1,0 +1,127 @@
+package io.redlink.more.studymanager.model.audit;
+
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class AuditLog {
+
+    public enum ActionState {
+        /**
+         * 2xx Responses or not <code>null</code> return values
+         */
+        success,
+        /**
+         * 3xx Responses
+         */
+        redirect,
+        /**
+         * 4xx or 5xx responses, exceptions or <code>null</code> return values
+         */
+        error,
+        /**
+         * other such as 1xx responses
+         */
+        unknown
+    }
+
+    private Long id;
+    private Instant created;
+    private String userId; // User Identifier
+    private Long studyId;
+    private String action; // Action Taken
+    private ActionState actionState = ActionState.unknown; // The state of the aucited Action
+    private Instant timestamp; // Timestamp of the Action
+    private String resource; // Resource Accessed
+    private Map<String, Object> details = new HashMap<>();// Additional Details
+
+    /**
+     * Constructor to create new AuditLogs
+     * @param userId the user - MUST NOT be <code>null</code>
+     * @param studyId the affected study - MUST NOT be <code>null</code>
+     * @param action the performed action - MUST NOT be <code>null</code>
+     * @param timestamp the timestamp or <code>null</code> to use the current time
+     */
+    public AuditLog(String userId, Long studyId, String action, Instant timestamp) {
+        this.id = null; // to be auto generated
+        this.created = null;
+        this.studyId = Objects.requireNonNull(studyId);
+        this.userId = Objects.requireNonNull(userId);
+        this.action = Objects.requireNonNull(action);
+        this.timestamp = timestamp == null ? Instant.now() : timestamp;
+    }
+
+    /**
+     * Constructor to create a AuditLog from data stored in the repository
+     * @param id DB generated id
+     * @param created DB generated created timestamp
+     * @param userId
+     * @param studyId
+     * @param action
+     * @param timestamp
+     */
+    public AuditLog(Long id, Instant created, String userId, Long studyId, String action, Instant timestamp) {
+        this.id = id;
+        this.created = created;
+        this.userId = Objects.requireNonNull(userId);
+        this.studyId = Objects.requireNonNull(studyId);
+        this.action = Objects.requireNonNull(action);
+        this.timestamp = Objects.requireNonNull(timestamp);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Instant getCreated() {
+        return created;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public AuditLog setActionState(ActionState actionState) {
+        this.actionState = actionState;
+        return this;
+    }
+
+    public ActionState getActionState() {
+        return actionState;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public Long getStudyId() {
+        return studyId;
+    }
+
+    public Map<String, Object> getDetails() {
+        return details;
+    }
+
+    public AuditLog setDetails(Map<String, Object> details) {
+        this.details = details == null ? new HashMap<>() : details;
+        return this;
+    }
+
+    public String getResource() {
+        return resource;
+    }
+
+    public AuditLog setResource(String resource) {
+        this.resource = resource;
+        return this;
+    }
+
+
+
+}

--- a/studymanager/src/main/java/io/redlink/more/studymanager/properties/AuditProperties.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/properties/AuditProperties.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Elastic License 2.0.
+ */
+package io.redlink.more.studymanager.properties;
+
+import io.redlink.more.studymanager.model.Study;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.Collection;
+
+@ConfigurationProperties(prefix = "audit")
+public record AuditProperties(
+    Collection<Study.Status> studyStates,
+    long detailsByteLimit
+) {
+}
+

--- a/studymanager/src/main/java/io/redlink/more/studymanager/repository/AuditLogRepository.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/repository/AuditLogRepository.java
@@ -1,0 +1,115 @@
+package io.redlink.more.studymanager.repository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.type.MapType;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.redlink.more.studymanager.exception.BadRequestException;
+import io.redlink.more.studymanager.model.audit.AuditLog;
+import io.redlink.more.studymanager.utils.MapperUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TimeZone;
+
+@Component
+public class AuditLogRepository {
+    private static final Logger LOG = LoggerFactory.getLogger(AuditLogRepository.class);
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .setTimeZone(TimeZone.getTimeZone(ZoneOffset.UTC))
+            .setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ"));
+
+
+    private static final MapType DETAILS_MAP_TYPE = MapperUtils.MAPPER.getTypeFactory()
+            .constructMapType(Map.class, String.class, Object.class);
+
+    private static final String INSERT_AUDIT_LOG =
+            "INSERT INTO audit_logs (user_id, study_id, action, state, timestamp, resource, details) " +
+            "VALUES (:user_id, :study_id, :action, CAST(:state AS audit_action_state), :timestamp, :resource, :details ) " +
+            "RETURNING *";
+
+    private static final String CLEAR_AUDIT_LOG = "DELETE FROM audit_logs";
+
+
+    private final JdbcTemplate template;
+    private final NamedParameterJdbcTemplate namedTemplate;
+
+    public AuditLogRepository(JdbcTemplate template) {
+        this.template = template;
+        this.namedTemplate = new NamedParameterJdbcTemplate(template);
+    }
+
+    public AuditLog insert(AuditLog auditLog) {
+        try {
+            return namedTemplate.queryForObject(INSERT_AUDIT_LOG, toParams(auditLog), getAuditLogRowMapper());
+        } catch (DataIntegrityViolationException e) {
+            throw new BadRequestException("Study " + auditLog.getStudyId() + " does not exist");
+        }
+    }
+
+
+    private MapSqlParameterSource toParams(AuditLog auditLog) {
+        var params = new MapSqlParameterSource()
+                .addValue("id", auditLog.getId())
+                .addValue("user_id", auditLog.getUserId())
+                .addValue("action", auditLog.getAction())
+                .addValue("state", auditLog.getActionState().name())
+                .addValue("timestamp", Timestamp.from(auditLog.getTimestamp()))
+                .addValue("study_id", auditLog.getStudyId())
+                .addValue("resource", auditLog.getResource());
+
+        try {
+            params.addValue("details", auditLog.getDetails().isEmpty() ? null :
+                            MAPPER.writeValueAsString(auditLog.getDetails()));
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("AuditLog details could not be serialized as JSON ", e);
+        }
+        return params;
+    }
+
+    private static RowMapper<AuditLog> getAuditLogRowMapper() {
+        return (rs, rowNum) -> {
+            final AuditLog auditLog = new AuditLog(
+                    rs.getLong("id"),
+                    RepositoryUtils.readInstant(rs, "created"),
+                    rs.getString("user_id"),
+                    rs.getLong("study_id"),
+                    rs.getString("action"),
+                    RepositoryUtils.readInstant(rs,"timestamp")
+            )
+                    .setResource(rs.getString("resource"))
+                    .setActionState(AuditLog.ActionState.valueOf(rs.getString("state")));
+            String detailsStr = rs.getString("details");
+            if (detailsStr != null) {
+                try {
+                    auditLog.setDetails(MAPPER.readValue(detailsStr, DETAILS_MAP_TYPE));
+                } catch (JsonProcessingException e) {
+                    LOG.warn("Unable to parse 'details' for AuditLog[id: {}] ({}:{})", auditLog.getId(), e.getClass().getSimpleName(), e.getMessage(), e);
+                }
+            } else {
+                auditLog.setDetails(new HashMap<>());
+            }
+            return  auditLog;
+        };
+    }
+
+    //for test purposes only
+    final void clear() {
+        template.execute(CLEAR_AUDIT_LOG);
+    }
+}

--- a/studymanager/src/main/java/io/redlink/more/studymanager/repository/StudyRepository.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/repository/StudyRepository.java
@@ -14,6 +14,8 @@ import io.redlink.more.studymanager.model.StudyRole;
 import io.redlink.more.studymanager.model.User;
 import io.redlink.more.studymanager.model.scheduler.Duration;
 import io.redlink.more.studymanager.utils.MapperUtils;
+
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -201,7 +203,7 @@ public class StudyRepository {
         return template.query(LIST_STUDIES_BY_STATUS, getStudyRowMapper(), status.getValue());
     }
 
-    public boolean hasState(long studyId, Set<Study.Status> allowedStates){
+    public boolean hasState(long studyId, Collection<Study.Status> allowedStates){
         if(allowedStates.isEmpty())
             return false;
         try(

--- a/studymanager/src/main/java/io/redlink/more/studymanager/service/AuditService.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/service/AuditService.java
@@ -1,0 +1,49 @@
+package io.redlink.more.studymanager.service;
+
+import io.redlink.more.studymanager.model.audit.AuditLog;
+import io.redlink.more.studymanager.properties.AuditProperties;
+import io.redlink.more.studymanager.repository.AuditLogRepository;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@EnableConfigurationProperties(AuditProperties.class)
+public class AuditService {
+
+    private final AuditProperties auditProperties;
+    private final AuditLogRepository auditLogRepository;
+    private final StudyStateService studystateService;
+    AuditService(
+            AuditProperties auditProperties,
+            AuditLogRepository auditLogRepository,
+            StudyStateService studystateService
+    ) {
+        this.auditProperties = auditProperties;
+        this.auditLogRepository = auditLogRepository;
+        this.studystateService = studystateService;
+    }
+
+    /**
+     * Records the parsed auditLog if the referenced study is in a state that requires audits. Otherwise
+     * the parsed log in not recorded and an empty {@link Optional} is returned
+     * @param auditLog the auditLog to record
+     * @return the recorded AuditLog (with '<code>id</code>') or an empty Optional if the parsed log was not recoded
+     */
+    public Optional<AuditLog> record(AuditLog auditLog){
+        if(auditLog == null){
+            return null;
+        } else if(auditLog.getId() != null){
+            throw new IllegalArgumentException("Unable to record existing AuditLog. The 'id' of the parsed AuditLog MUST BE NULL!");
+        }
+        if(auditProperties.studyStates() == null ||
+                auditProperties.studyStates().isEmpty() ||
+                studystateService.hasStudyState(auditLog.getStudyId(), auditProperties.studyStates())){
+            return Optional.of(auditLogRepository.insert(auditLog));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+}

--- a/studymanager/src/main/java/io/redlink/more/studymanager/service/StudyStateService.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/service/StudyStateService.java
@@ -13,6 +13,7 @@ import io.redlink.more.studymanager.model.Study;
 import io.redlink.more.studymanager.repository.StudyRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.Set;
 
@@ -30,7 +31,7 @@ public class StudyStateService {
         return study;
     }
 
-    public Study assertStudyNotInState(final Study study, Set<Study.Status> states) {
+    public Study assertStudyNotInState(final Study study, Collection<Study.Status> states) {
         assertStudyNotInState(study.getStudyId(), states);
         return study;
     }
@@ -39,7 +40,7 @@ public class StudyStateService {
         return assertStudyNotInState(studyId, Set.of(states));
     }
 
-    public Long assertStudyNotInState(Long studyId, Set<Study.Status> states) {
+    public Long assertStudyNotInState(Long studyId, Collection<Study.Status> states) {
         return assertStudyState(studyId, EnumSet.complementOf(EnumSet.copyOf(states)));
     }
 
@@ -48,7 +49,7 @@ public class StudyStateService {
         return study;
     }
 
-    public Study assertStudyState(final Study study, Set<Study.Status> states) {
+    public Study assertStudyState(final Study study, Collection<Study.Status> states) {
         assertStudyState(study.getStudyId(), states);
         return study;
     }
@@ -57,11 +58,17 @@ public class StudyStateService {
         return assertStudyState(studyId, Set.of(states));
     }
 
-    public Long assertStudyState(Long studyId, Set<Study.Status> states) {
-        if (studyId == null)
-            throw new IllegalArgumentException("studyId must not be null");
-        if (studyRepository.hasState(studyId, states))
+    public Long assertStudyState(Long studyId, Collection<Study.Status> states) {
+        if(hasStudyState(studyId, states)){
             return studyId;
+        }
         throw BadStudyStateException.state();
     }
+
+    public boolean hasStudyState(Long studyId, Collection<Study.Status> states) {
+        if (studyId == null)
+            throw new IllegalArgumentException("studyId must not be null");
+        return studyRepository.hasState(studyId, states);
+    }
+
 }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/utils/MapperUtils.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/utils/MapperUtils.java
@@ -11,7 +11,12 @@ package io.redlink.more.studymanager.utils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.google.common.io.CountingOutputStream;
 import io.redlink.more.studymanager.exception.BadRequestException;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 public class MapperUtils {
     public static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new JavaTimeModule());
@@ -35,6 +40,58 @@ public class MapperUtils {
             return MAPPER.writeValueAsString(o);
         } catch (JsonProcessingException e) {
             throw new BadRequestException(e);
+        }
+    }
+
+    /**
+     * Validates if the given object can be serialized to JSON.
+     * @param obj The object to validate.
+     * @return true if serializable, false otherwise.
+     */
+    public static boolean isSerializable(Object obj) {
+        return isSerializable(obj, -1);
+    }
+
+    /**
+     * Validates if the given object can be serialized to JSON.
+     * @param obj The object to validate.
+     * @param byteLimit The limit of bytes allowed to serialize the parsed object.
+     *                  Parse <code>%lt;= 0</code> for no limit.
+     *                  NOTE that for primitive types and numbers the byte limit is ignored.
+     * @return true if serializable, false otherwise.
+     */
+    public static boolean isSerializable(Object obj, long byteLimit) {
+        //catch some commone cases
+        if(obj == null) return true;
+        Class<?> clazz = obj.getClass();
+        if(clazz.isPrimitive() || clazz.isAssignableFrom(Number.class)) return true;
+        //For String we want to consider the parsed byteLimit as this might include very long strings
+        if(clazz.equals(String.class) && byteLimit > 0 &&
+                (((String)obj).length() * 4L <= byteLimit || ((String)obj).getBytes(StandardCharsets.UTF_8).length <= byteLimit)) {
+            return true;
+        }
+        //just try to serialize it
+        try(CountingOutputStream out = new CountingOutputStream(new NullOutputStream())) {
+            // Serialize to a no-op OutputStream to avoid producing unnecessary output
+            MAPPER.writeValue(out, obj);
+            return byteLimit <= 0 || out.getCount() <= byteLimit;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    /**
+     * No-op OutputStream that discards all data
+     */
+    private static class NullOutputStream extends OutputStream {
+        @Override
+        public void write(int b) {
+            // Do nothing
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) {
+            // Do nothing
         }
     }
 }

--- a/studymanager/src/main/resources/application.yaml
+++ b/studymanager/src/main/resources/application.yaml
@@ -113,3 +113,11 @@ more:
       server: "${MORE_FE_KC_SERVER:https://auth.more.redlink.io/}"
       realm: "${MORE_FE_KC_REALM:Auth-Client-Test}"
       client-id: "${MORE_FE_KC_CLIENT_ID:oauth2-pkce-client}"
+
+  audit:
+    # the study.status to audit (fallback if not set: all)
+    study-states:
+      - active
+      - paused
+      - closed
+    details-byte-limit: 1000

--- a/studymanager/src/main/resources/db/migration/V1_16_0__add_audit_logs.sql
+++ b/studymanager/src/main/resources/db/migration/V1_16_0__add_audit_logs.sql
@@ -1,0 +1,20 @@
+-- create table for storing audit_logs
+CREATE TYPE audit_action_state AS ENUM ('success', 'redirect', 'error', 'unknown');
+
+CREATE TABLE audit_logs (
+     id BIGSERIAL PRIMARY KEY,
+     user_id VARCHAR NOT NULL,
+     study_id BIGINT NOT NULL,
+     action VARCHAR NOT NULL,
+     timestamp TIMESTAMP NOT NULL,
+     state audit_action_state NOT NULL default 'unknown',
+     resource VARCHAR,
+     details TEXT,
+     created TIMESTAMP NOT NULL DEFAULT now()
+);
+
+CREATE INDEX audit_by_time ON audit_logs (timestamp);
+CREATE INDEX audit_by_state ON audit_logs (state, timestamp);
+CREATE INDEX audit_by_study ON audit_logs (study_id, timestamp);
+CREATE INDEX audit_by_user ON audit_logs (study_id, timestamp);
+CREATE INDEX audit_by_action ON audit_logs (action, timestamp);

--- a/studymanager/src/test/java/io/redlink/more/studymanager/audit/AuditAspectTest.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/audit/AuditAspectTest.java
@@ -1,0 +1,260 @@
+package io.redlink.more.studymanager.audit;
+
+import io.redlink.more.studymanager.api.v1.model.StudyDTO;
+import io.redlink.more.studymanager.model.AuthenticatedUser;
+import io.redlink.more.studymanager.model.PlatformRole;
+import io.redlink.more.studymanager.model.Study;
+import io.redlink.more.studymanager.model.audit.AuditLog;
+import io.redlink.more.studymanager.properties.AuditProperties;
+import io.redlink.more.studymanager.service.AuditService;
+import io.redlink.more.studymanager.service.OAuth2AuthenticationService;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.Signature;
+import org.aspectj.lang.reflect.CodeSignature;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import java.net.URI;
+import java.util.*;
+import java.util.function.Predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+public class AuditAspectTest {
+
+    AuditService auditService = Mockito.mock(AuditService.class);
+    OAuth2AuthenticationService authService = Mockito.mock(OAuth2AuthenticationService.class);
+    AuthenticatedUser authUser = Mockito.mock(AuthenticatedUser.class);
+
+    AuditAspect auditAspect = new AuditAspect(
+            new AuditProperties(EnumSet.of(Study.Status.ACTIVE, Study.Status.PAUSED, Study.Status.CLOSED), -1L),
+            auditService,
+            authService);
+
+    @Before
+    public void setup() {
+        when(authUser.id()).thenReturn("test-user");
+        when(authUser.roles()).thenReturn(Set.of(PlatformRole.MORE_VIEWER));
+        when(authService.getCurrentUser()).thenReturn(authUser);
+        when(auditService.record(any())).thenAnswer(invocationOnMock -> Optional.of(invocationOnMock.getArguments()[0]));
+    }
+
+    @Test
+    public void testRecordStudyActivity() throws Throwable {
+
+        // Creating mock objects
+        JoinPoint joinPoint = Mockito.mock(JoinPoint.class);
+        CodeSignature signature = Mockito.mock(CodeSignature.class);
+        ResponseEntity<Void> responseEntity = Mockito.mock(ResponseEntity.class);
+        HttpHeaders httpHeaders = Mockito.mock(HttpHeaders.class);
+
+        when(responseEntity.getStatusCode()).thenReturn(HttpStatus.OK);
+        when(responseEntity.getHeaders()).thenReturn(httpHeaders);
+        when(httpHeaders.getContentType()).thenReturn(MediaType.APPLICATION_JSON);
+        when(httpHeaders.getLocation()).thenReturn(null);
+
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(signature.toLongString()).thenReturn("test-signature-long-string");
+        when(signature.getParameterNames()).thenReturn(new String[]{"studyId", "participantId", "groupId"});
+        when(signature.getParameterTypes()).thenReturn(new Class[]{Long.class, Integer.class, Integer.class});
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, 2, 3});
+
+        auditAspect.recordActivity(joinPoint, responseEntity);
+
+        ArgumentCaptor<AuditLog> captor = ArgumentCaptor.forClass(AuditLog.class);
+        verify(auditService,times(1)).record(captor.capture());
+
+        AuditLog auditLog = captor.getValue();
+
+        assertThat(auditLog).isNotNull();
+        assertThat(auditLog.getId()).isNull(); //assigned by the DB
+        assertThat(auditLog.getCreated()).isNull(); //assigned by the DB
+        assertThat(auditLog.getUserId()).isEqualTo("test-user");
+        assertThat(auditLog.getStudyId()).isEqualTo(1L);
+        assertThat(auditLog.getAction()).isEqualTo("test-signature-long-string");
+        assertThat(auditLog.getActionState()).isEqualTo(AuditLog.ActionState.success);
+        assertThat(auditLog.getTimestamp()).isNotNull();
+        assertThat(auditLog.getResource()).isNull();
+        assertThat(auditLog.getDetails()).isNotNull();
+        assertThat(auditLog.getDetails().get("param_participantId")).isEqualTo(2);
+        assertThat(auditLog.getDetails().get("param_groupId")).isEqualTo(3);
+        assertThat(auditLog.getDetails().get("header_content-type")).isEqualTo(MediaType.APPLICATION_JSON_VALUE);
+
+    }
+    @Test
+    public void testStudyIdFromReturnValue() throws Throwable {
+
+        // Creating mock objects
+        JoinPoint joinPoint = Mockito.mock(JoinPoint.class);
+        CodeSignature signature = Mockito.mock(CodeSignature.class);
+        ResponseEntity<StudyDTO> responseEntity = Mockito.mock(ResponseEntity.class);
+        StudyDTO  studyDTO = Mockito.mock(StudyDTO.class);
+        HttpHeaders httpHeaders = Mockito.mock(HttpHeaders.class);
+
+        when(responseEntity.getStatusCode()).thenReturn(HttpStatus.OK);
+        when(responseEntity.getHeaders()).thenReturn(httpHeaders);
+        when(responseEntity.getBody()).thenReturn(studyDTO);
+        when(httpHeaders.getContentType()).thenReturn(MediaType.APPLICATION_JSON);
+        when(httpHeaders.getLocation()).thenReturn(null);
+        when(studyDTO.getStudyId()).thenReturn(5L);
+
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(signature.toLongString()).thenReturn("test-signature-long-string");
+        when(signature.getParameterNames()).thenReturn(new String[]{});
+        when(signature.getParameterTypes()).thenReturn(new Class[]{});
+        when(joinPoint.getArgs()).thenReturn(new Object[]{});
+
+        auditAspect.recordActivity(joinPoint, responseEntity);
+
+        ArgumentCaptor<AuditLog> captor = ArgumentCaptor.forClass(AuditLog.class);
+        verify(auditService,times(1)).record(captor.capture());
+
+        AuditLog auditLog = captor.getValue();
+
+        assertThat(auditLog).isNotNull();
+        assertThat(auditLog.getId()).isNull(); //assigned by the DB
+        assertThat(auditLog.getCreated()).isNull(); //assigned by the DB
+        assertThat(auditLog.getUserId()).isEqualTo("test-user");
+        assertThat(auditLog.getStudyId()).isEqualTo(5L);
+        assertThat(auditLog.getAction()).isEqualTo("test-signature-long-string");
+        assertThat(auditLog.getActionState()).isEqualTo(AuditLog.ActionState.success);
+        assertThat(auditLog.getTimestamp()).isNotNull();
+        assertThat(auditLog.getResource()).isNull();
+        assertThat(auditLog.getDetails()).isNotNull();
+        assertThat(auditLog.getDetails().get("header_content-type")).isEqualTo(MediaType.APPLICATION_JSON_VALUE);
+        assertThat(auditLog.getDetails().get("user_roles")).isEqualTo(List.of(PlatformRole.MORE_VIEWER.name()));
+    }
+
+    @Test
+    public void test4xxResponseToActionState() throws Throwable {
+
+        // Creating mock objects
+        JoinPoint joinPoint = Mockito.mock(JoinPoint.class);
+        CodeSignature signature = Mockito.mock(CodeSignature.class);
+        ResponseEntity<Void> responseEntity = Mockito.mock(ResponseEntity.class);
+        HttpHeaders httpHeaders = Mockito.mock(HttpHeaders.class);
+
+        when(responseEntity.getStatusCode()).thenReturn(HttpStatus.BAD_REQUEST);
+        when(responseEntity.getHeaders()).thenReturn(httpHeaders);
+        when(httpHeaders.getContentType()).thenReturn(null);
+        when(httpHeaders.getLocation()).thenReturn(null);
+
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(signature.toLongString()).thenReturn("test-signature-long-string");
+        when(signature.getParameterNames()).thenReturn(new String[]{"studyId"});
+        when(signature.getParameterTypes()).thenReturn(new Class[]{Long.class});
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L});
+
+        auditAspect.recordActivity(joinPoint, responseEntity);
+
+        ArgumentCaptor<AuditLog> captor = ArgumentCaptor.forClass(AuditLog.class);
+        verify(auditService,times(1)).record(captor.capture());
+
+        AuditLog auditLog = captor.getValue();
+
+        assertThat(auditLog).isNotNull();
+        assertThat(auditLog.getId()).isNull(); //assigned by the DB
+        assertThat(auditLog.getCreated()).isNull(); //assigned by the DB
+        assertThat(auditLog.getUserId()).isEqualTo("test-user");
+        assertThat(auditLog.getStudyId()).isEqualTo(1L);
+        assertThat(auditLog.getAction()).isEqualTo("test-signature-long-string");
+        assertThat(auditLog.getActionState()).isEqualTo(AuditLog.ActionState.error);
+        assertThat(auditLog.getTimestamp()).isNotNull();
+        assertThat(auditLog.getResource()).isNull();
+        assertThat(auditLog.getDetails()).isNotNull();
+        assertThat(auditLog.getDetails().get("header_content-type")).isNull();
+        assertThat(auditLog.getDetails().get("user_roles")).isEqualTo(List.of(PlatformRole.MORE_VIEWER.name()));
+    }
+
+    @Test
+    public void test5xxResponseToActionState() throws Throwable {
+        // Creating mock objects
+        JoinPoint joinPoint = Mockito.mock(JoinPoint.class);
+        CodeSignature signature = Mockito.mock(CodeSignature.class);
+        ResponseEntity<Void> responseEntity = Mockito.mock(ResponseEntity.class);
+        HttpHeaders httpHeaders = Mockito.mock(HttpHeaders.class);
+
+        when(responseEntity.getStatusCode()).thenReturn(HttpStatus.INTERNAL_SERVER_ERROR);
+        when(responseEntity.getHeaders()).thenReturn(httpHeaders);
+        when(httpHeaders.getContentType()).thenReturn(null);
+        when(httpHeaders.getLocation()).thenReturn(null);
+
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(signature.toLongString()).thenReturn("test-signature-long-string");
+        when(signature.getParameterNames()).thenReturn(new String[]{"studyId"});
+        when(signature.getParameterTypes()).thenReturn(new Class[]{Long.class});
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L});
+
+        auditAspect.recordActivity(joinPoint, responseEntity);
+
+        ArgumentCaptor<AuditLog> captor = ArgumentCaptor.forClass(AuditLog.class);
+        verify(auditService,times(1)).record(captor.capture());
+
+        AuditLog auditLog = captor.getValue();
+
+        assertThat(auditLog).isNotNull();
+        assertThat(auditLog.getId()).isNull(); //assigned by the DB
+        assertThat(auditLog.getCreated()).isNull(); //assigned by the DB
+        assertThat(auditLog.getUserId()).isEqualTo("test-user");
+        assertThat(auditLog.getStudyId()).isEqualTo(1L);
+        assertThat(auditLog.getAction()).isEqualTo("test-signature-long-string");
+        assertThat(auditLog.getActionState()).isEqualTo(AuditLog.ActionState.error);
+        assertThat(auditLog.getTimestamp()).isNotNull();
+        assertThat(auditLog.getResource()).isNull();
+        assertThat(auditLog.getDetails()).isNotNull();
+        assertThat(auditLog.getDetails().get("header_content-type")).isNull();
+        assertThat(auditLog.getDetails().get("user_roles")).isEqualTo(List.of(PlatformRole.MORE_VIEWER.name()));
+    }
+
+    @Test
+    public void test3xxResponseToActionState() throws Throwable {
+        // Creating mock objects
+        JoinPoint joinPoint = Mockito.mock(JoinPoint.class);
+        CodeSignature signature = Mockito.mock(CodeSignature.class);
+        ResponseEntity<Void> responseEntity = Mockito.mock(ResponseEntity.class);
+        HttpHeaders httpHeaders = Mockito.mock(HttpHeaders.class);
+
+        URI seeOther = new URI("http://see-other.more.at/study/1/other");
+
+        when(responseEntity.getStatusCode()).thenReturn(HttpStatus.SEE_OTHER);
+        when(responseEntity.getHeaders()).thenReturn(httpHeaders);
+        when(httpHeaders.getContentType()).thenReturn(null);
+        when(httpHeaders.getLocation()).thenReturn(seeOther);
+
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(signature.toLongString()).thenReturn("test-signature-long-string");
+        when(signature.getParameterNames()).thenReturn(new String[]{"studyId"});
+        when(signature.getParameterTypes()).thenReturn(new Class[]{Long.class});
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L});
+
+        auditAspect.recordActivity(joinPoint, responseEntity);
+
+        ArgumentCaptor<AuditLog> captor = ArgumentCaptor.forClass(AuditLog.class);
+        verify(auditService,times(1)).record(captor.capture());
+
+        AuditLog auditLog = captor.getValue();
+
+        assertThat(auditLog).isNotNull();
+        assertThat(auditLog.getId()).isNull(); //assigned by the DB
+        assertThat(auditLog.getCreated()).isNull(); //assigned by the DB
+        assertThat(auditLog.getUserId()).isEqualTo("test-user");
+        assertThat(auditLog.getStudyId()).isEqualTo(1L);
+        assertThat(auditLog.getAction()).isEqualTo("test-signature-long-string");
+        assertThat(auditLog.getActionState()).isEqualTo(AuditLog.ActionState.redirect);
+        assertThat(auditLog.getTimestamp()).isNotNull();
+        assertThat(auditLog.getResource()).isNull();
+        assertThat(auditLog.getDetails()).isNotNull();
+        assertThat(auditLog.getDetails().get("header_location")).isEqualTo(seeOther.toString());
+        assertThat(auditLog.getDetails().get("user_roles")).isEqualTo(List.of(PlatformRole.MORE_VIEWER.name()));
+        }
+}

--- a/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/StudyPermissionControllerTest.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/StudyPermissionControllerTest.java
@@ -8,12 +8,19 @@
  */
 package io.redlink.more.studymanager.controller.studymanager;
 
+import io.redlink.more.studymanager.model.AuthenticatedUser;
 import io.redlink.more.studymanager.model.MoreUser;
+import io.redlink.more.studymanager.model.PlatformRole;
 import io.redlink.more.studymanager.model.StudyRole;
+import io.redlink.more.studymanager.service.OAuth2AuthenticationService;
 import io.redlink.more.studymanager.service.StudyPermissionService;
 import io.redlink.more.studymanager.service.StudyService;
+
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,10 +55,21 @@ class StudyPermissionControllerTest {
     @MockitoBean
     StudyPermissionService studyPermissionService;
 
+    @MockitoBean
+    OAuth2AuthenticationService authService;
+
     @Autowired
     private WebApplicationContext context;
 
     private MockMvc mvc;
+
+    private final AuthenticatedUser authUser = new AuthenticatedUser(
+            UUID.randomUUID().toString(),
+            "More User",
+            "more@example.com",
+            "The Hospital",
+            EnumSet.allOf(PlatformRole.class));
+
 
     @BeforeEach
     void init() {
@@ -73,6 +91,7 @@ class StudyPermissionControllerTest {
     @Test
     @WithMockUser
     void testRoleChecksAccepted() throws Exception {
+        when(authService.getCurrentUser()).thenReturn(authUser); //required by AuditLogging
         when(studyPermissionService.hasAnyRole(anyLong(),anyString(),anySet())).thenReturn(true);
         when(studyService.getACL(anyLong())).thenReturn(Map.of(new MoreUser("test","test","test","test"), Set.of(StudyRole.STUDY_VIEWER)));
         mvc.perform(get("/api/v1/studies/1/collaborators")

--- a/studymanager/src/test/java/io/redlink/more/studymanager/repository/AuditLogRepositoryTest.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/repository/AuditLogRepositoryTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Elastic License 2.0.
+ */
+package io.redlink.more.studymanager.repository;
+
+import io.redlink.more.studymanager.core.properties.ActionProperties;
+import io.redlink.more.studymanager.model.Action;
+import io.redlink.more.studymanager.model.audit.AuditLog;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Testcontainers
+@ActiveProfiles("test-containers-flyway")
+class AuditLogRepositoryTest {
+    @Autowired
+    private AuditLogRepository auditLogRepository;
+
+    @BeforeEach
+    void deleteAll() {
+        auditLogRepository.clear();
+    }
+
+    @Test
+    @DisplayName("Create AuditLog")
+    void testInsert() {
+        String userId = "test-user";
+        Long studyId = 1L;
+        String actionId = "test-action";
+        Instant timestamp = Instant.now().minusSeconds(10).truncatedTo(ChronoUnit.SECONDS);
+        Action detailsAction = new Action()
+                .setType("test")
+                .setProperties(new ActionProperties(Map.of("test","dummy")))
+                .setCreated(timestamp.minusSeconds(5))
+                .setModified(timestamp);
+
+        Instant detailsTimestamp = timestamp.minusSeconds(10);
+        Map<String,Object> details = Map.of(
+                "detail_state", Boolean.TRUE,
+                "detail_integer", 42,
+                "detail_number", 3.1415,
+                "detail_text", "This is an important test",
+                "detail_bean", detailsAction,
+                "details_timestamp", detailsTimestamp);
+
+        AuditLog auditLog = new AuditLog(
+                userId,
+                studyId,
+                actionId,
+                timestamp)
+                .setDetails(details)
+                .setActionState(AuditLog.ActionState.success);
+
+        AuditLog auditLogResonse = auditLogRepository.insert(auditLog);
+
+        assertThat(auditLogResonse).isNotNull();
+        //assert that the ID and the created timestamp are initialised by the DB
+        assertThat(auditLogResonse.getId()).isNotNull();
+        assertThat(auditLogResonse.getCreated()).isNotNull();
+        assertThat(auditLogResonse.getCreated()).isBetween(timestamp, Instant.now().plusMillis(1));
+        //assert the values of the AuditLog
+        assertThat(auditLogResonse.getUserId()).isEqualTo(userId);
+        assertThat(auditLogResonse.getStudyId()).isEqualTo(studyId);
+        assertThat(auditLogResonse.getAction()).isEqualTo(actionId);
+        assertThat(auditLogResonse.getTimestamp()).isEqualTo(timestamp);
+        assertThat(auditLogResonse.getActionState()).isEqualTo(AuditLog.ActionState.success);
+        //assert Details
+        assertThat(auditLogResonse.getDetails()).isNotNull();
+        assertThat(auditLogResonse.getDetails().keySet()).isEqualTo(details.keySet());
+        assertThat(auditLogResonse.getDetails().get("detail_state")).isEqualTo(Boolean.TRUE);
+        assertThat(auditLogResonse.getDetails().get("detail_integer")).isEqualTo(42);
+        assertThat(auditLogResonse.getDetails().get("detail_number")).isEqualTo(3.1415);
+        assertThat(auditLogResonse.getDetails().get("detail_text")).isEqualTo("This is an important test");
+        //NOTE: Date/Time and Instant values are written as UTC date/time strings
+        assertThat(auditLogResonse.getDetails().get("details_timestamp")).isEqualTo(detailsTimestamp.toString());
+
+        //Validate Details
+        //NOTE: class information is lost. So the returned AuditLog will contain the information as Map<String,Object>
+        assertThat(auditLogResonse.getDetails().get("detail_bean")).isInstanceOf(Map.class);
+        Map<String,Object> detailsBean = (Map<String,Object>) auditLogResonse.getDetails().get("detail_bean");
+        assertThat(detailsBean.get("type")).isEqualTo("test");
+        assertThat(detailsBean.get("properties")).isEqualTo(Map.of("test","dummy"));
+        //NOTE: Date/Time and Instant values are written as UTC date/time strings
+        assertThat(detailsBean.get("created")).isEqualTo(detailsAction.getCreated().toString());
+        assertThat(detailsBean.get("modified")).isEqualTo(detailsAction.getModified().toString());
+    }
+}

--- a/studymanager/src/test/java/io/redlink/more/studymanager/service/AuditServiceTest.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/service/AuditServiceTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Elastic License 2.0.
+ */
+package io.redlink.more.studymanager.service;
+
+import io.redlink.more.studymanager.exception.BadRequestException;
+import io.redlink.more.studymanager.model.*;
+import io.redlink.more.studymanager.model.audit.AuditLog;
+import io.redlink.more.studymanager.properties.AuditProperties;
+import io.redlink.more.studymanager.repository.AuditLogRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuditServiceTest {
+
+    @Mock
+    AuditLogRepository auditLogRepository;
+
+    @Mock
+    StudyStateService studyStateService;
+
+    @Mock
+    AuditProperties auditProperties;
+
+    @InjectMocks
+    AuditService auditService;
+
+    private final AuthenticatedUser currentUser = new AuthenticatedUser(
+            UUID.randomUUID().toString(),
+            "Test User", "test@example.com", "Test Inc.",
+            EnumSet.allOf(PlatformRole.class)
+    );
+
+    @Test
+    @DisplayName("When the auditLog is saved it should return the study with id and created date.")
+    void testRecord() {
+        AuditLog auditLog = new AuditLog(
+                currentUser.id(),
+                1L,
+                "test-action",
+                Instant.now().minusSeconds(10))
+                .setActionState(AuditLog.ActionState.success)
+                .setDetails(Map.of("test","dummy"));
+
+        when(auditLogRepository.insert(any(AuditLog.class)))
+                .thenAnswer(invocationOnMock -> {
+                    var al = (AuditLog) invocationOnMock.getArguments()[0];
+                    return new AuditLog(1L,Instant.now(), al.getUserId(), al.getStudyId(), al.getAction(),al.getTimestamp())
+                            .setActionState(al.getActionState())
+                            .setDetails(al.getDetails())
+                            .setResource(al.getResource());
+                });
+        //when(studyStateService.hasStudyState(any(), any())).thenReturn(true);
+
+        //when(auditProperties.detailsByteLimit()).thenReturn(-1L);
+        when(auditProperties.studyStates()).thenReturn(new LinkedList<>());
+
+        Optional<AuditLog> auditLogResponse = auditService.record(auditLog);
+
+        assertThat(auditLogResponse).isPresent();
+        assertThat(auditLogResponse.get().getId()).isEqualTo(1L);
+        assertThat(auditLogResponse.get().getId()).isNotNull();
+
+
+    }
+
+    @Test
+    @DisplayName("When the auditLog is not saved for a study in a state that does not require auditing")
+    void testSkipRecord() {
+        AuditLog auditLog = new AuditLog(
+                currentUser.id(),
+                1L,
+                "test-action",
+                Instant.now().minusSeconds(10))
+                .setActionState(AuditLog.ActionState.success)
+                .setDetails(Map.of("test","dummy"));
+
+        when(auditLogRepository.insert(any(AuditLog.class)))
+                .thenAnswer(invocationOnMock -> {
+                    var al = (AuditLog) invocationOnMock.getArguments()[0];
+                    return new AuditLog(1L,Instant.now(), al.getUserId(), al.getStudyId(), al.getAction(),al.getTimestamp())
+                            .setActionState(al.getActionState())
+                            .setDetails(al.getDetails())
+                            .setResource(al.getResource());
+                });
+        Collection<Study.Status> activeStudyStates = EnumSet.of(Study.Status.PAUSED,Study.Status.ACTIVE);
+        //test a not auditing study statefirst
+        when(studyStateService.hasStudyState(any(), eq(activeStudyStates))).thenReturn(false);
+
+        when(auditProperties.studyStates()).thenReturn(activeStudyStates);
+        Optional<AuditLog> auditLogResponse = auditService.record(auditLog);
+        assertThat(auditLogResponse).isNotPresent();
+
+        //test a auditing study state second
+        when(studyStateService.hasStudyState(any(), eq(activeStudyStates))).thenReturn(true);
+        Optional<AuditLog> auditLogResponse2 = auditService.record(auditLog);
+        assertThat(auditLogResponse2).isPresent();
+
+    }
+
+}


### PR DESCRIPTION
Implements an AuditLog for the StudiyManager Backend ([Issue MORE-Platform/more-studymanager-backend#413](https://github.com/MORE-Platform/more-studymanager-backend/issues/413) of the studymanager-frontend repository)

### AuditLog

The AuditLog includes:

* id - a unique id created by the DB
* created - the timestamp when the log was written to the database
* userId - the id of the authenticated user
* studyId - the id of the affected user
* Action - for now the full signature of the audited method
* State: `success`, `redirect`, `error` or `unknown`: Determined based on the method results. If applicable based on the http-status, `error` in case of an exception. `unknown` if it can not be determined
* timestamp - when the audited method completed
* resource - currently unused
* details: This includes additional information that are stored as JSON serialized string in the audit log
    * `param_<param-name>` additional parameters of the audited call. NOTE the maximum length of the JSON serialization of a parameter is limited via a config
    * `user_roles` - all roles assigned to the authenticated user for the given request
    * `header_content-type` the `content-type` http header
    * `header_location` the `location` http header

### Storage

The auditLog is stored in the MORE database in the table `audit_logs`

### Configuration

```yaml
  audit:
    # the study.status to audit (fallback if not set: all)
    study-states:
      - active
      - paused
      - closed
     details-byte-limit: 1000
```

The `study-states` define the states of studies where audit logging is active. If not set audit logs are active in all states. The `details-byte-limit` defines the maximum size of JSON String for parameter so that the serialization is included in the details of the audit log. This applies mainly to JSON parameters parsed in requests, but might also be triggered by long String values.

### Implementation

Auditing is implemented using Spring AoP (aspect oriented programming). The Aspect is bound to functionality (`JoinPoint`) using the `@Audited` Annotation. Only Methods with this annotation are considered for audit logging. The implementation assumes usage in `@RestController`, but is strictly not limited to it

Example Usage:

```java
    @Override
    @RequiresStudyRole(StudyRole.STUDY_ADMIN)
    @Audited
    public ResponseEntity<StudyDTO> setStatus(Long studyId, StatusChangeDTO statusChangeDTO) {
```
The affected `studyId` is extracted

* based on a `Long` parameter with the name `studyId`
* based on the return value being a `ResponseEntity<StudyDTO>` a `StudyDTO` or a `Study`

if the `studyId` can not be determined an Exception is thrown.