### PR TITLE
AuditLog fixes and user_name extension

### DIFF
--- a/studymanager/src/main/java/io/redlink/more/studymanager/audit/AuditAspect.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/audit/AuditAspect.java
@@ -77,7 +77,8 @@ public class AuditAspect {
         }
 
         AuditLog auditLog = new AuditLog(user.id(), studyId, action, timestamp)
-                .setActionState(getActionState(returnValue, e));
+                .setActionState(getActionState(returnValue, e))
+                .setUserName(user.fullName());
         //finally set some additional information (if available)
         auditLog.getDetails().putAll(parameters);
         auditLog.getDetails().put("user_roles", user.roles().stream().map(PlatformRole::name).toList());

--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/audit/AuditLog.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/audit/AuditLog.java
@@ -30,6 +30,7 @@ public class AuditLog {
     private Long id;
     private Instant created;
     private String userId; // User Identifier
+    private String userName; //the username at the time of the performed action
     private Long studyId;
     private String action; // Action Taken
     private ActionState actionState = ActionState.unknown; // The state of the audited Action
@@ -122,6 +123,12 @@ public class AuditLog {
         return this;
     }
 
+    public AuditLog setUserName(String userName) {
+        this.userName = userName;
+        return this;
+    }
 
-
+    public String getUserName() {
+        return userName;
+    }
 }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/AuditlogTransformer.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/AuditlogTransformer.java
@@ -28,10 +28,11 @@ public final class AuditlogTransformer {
             ).orElse(null);
         var auditLogEntry = new AuditLogEntryDTO()
                 .id(auditLog.getId())
+                .created(auditLog.getCreated())
                 .studyId(auditLog.getStudyId())
                 .userId(auditLog.getUserId())
                 .userRoles(userRoles) //the user roles as parsed from the details
-                //.userName(auditLog.getUserName()) TODO: getUserName From somewhere
+                .userName(auditLog.getUserName())
                 .timestamp(auditLog.getTimestamp())
                 .action(auditLog.getAction())
                 .actionState(AuditLogEntryDTO.ActionStateEnum.valueOf(auditLog.getActionState().name().toUpperCase()));

--- a/studymanager/src/main/java/io/redlink/more/studymanager/properties/AuditProperties.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/properties/AuditProperties.java
@@ -13,7 +13,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.Collection;
 
-@ConfigurationProperties(prefix = "audit")
+@ConfigurationProperties(prefix = "more.audit")
 public record AuditProperties(
     Collection<Study.Status> studyStates,
     long detailsByteLimit

--- a/studymanager/src/main/java/io/redlink/more/studymanager/repository/AuditLogRepository.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/repository/AuditLogRepository.java
@@ -39,8 +39,8 @@ public class AuditLogRepository {
             .constructMapType(Map.class, String.class, Object.class);
 
     private static final String INSERT_AUDIT_LOG =
-            "INSERT INTO audit_logs (user_id, study_id, action, state, timestamp, resource, details) " +
-            "VALUES (:user_id, :study_id, :action, CAST(:state AS audit_action_state), :timestamp, :resource, :details) " +
+            "INSERT INTO audit_logs (user_id, study_id, action, state, timestamp, resource, details, user_name) " +
+            "VALUES (:user_id, :study_id, :action, CAST(:state AS audit_action_state), :timestamp, :resource, :details, :user_name) " +
             "RETURNING *";
 
     private static final String CLEAR_AUDIT_LOG = "DELETE FROM audit_logs";
@@ -123,8 +123,8 @@ public class AuditLogRepository {
                 .addValue("state", auditLog.getActionState().name())
                 .addValue("timestamp", Timestamp.from(auditLog.getTimestamp()))
                 .addValue("study_id", auditLog.getStudyId())
-                .addValue("resource", auditLog.getResource());
-
+                .addValue("resource", auditLog.getResource())
+                .addValue("user_name", auditLog.getUserName());
         try {
             params.addValue("details", auditLog.getDetails().isEmpty() ? null :
                             MAPPER.writeValueAsString(auditLog.getDetails()));
@@ -145,7 +145,8 @@ public class AuditLogRepository {
                     RepositoryUtils.readInstant(rs,"timestamp")
             )
                     .setResource(rs.getString("resource"))
-                    .setActionState(AuditLog.ActionState.valueOf(rs.getString("state")));
+                    .setActionState(AuditLog.ActionState.valueOf(rs.getString("state")))
+                    .setUserName(rs.getString("user_name"));
             String detailsStr = rs.getString("details");
             if (detailsStr != null) {
                 try {

--- a/studymanager/src/main/resources/db/migration/V1_16_1__add_user_name_ti_audit_logs.sql
+++ b/studymanager/src/main/resources/db/migration/V1_16_1__add_user_name_ti_audit_logs.sql
@@ -1,0 +1,3 @@
+-- add a column to store the username to the audit_logs table
+ALTER TABLE audit_logs
+    ADD user_name VARCHAR;

--- a/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/AuditLogControllerTest.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/AuditLogControllerTest.java
@@ -94,7 +94,6 @@ class AuditLogControllerTest {
 
         Map<String,Object> details = Map.of(
                 "user_roles", List.of("admin", "viewer"),
-                "user_role", 1,
                 "detail_state", Boolean.TRUE,
                 "detail_integer", 42,
                 "detail_number", 3.1415,
@@ -103,20 +102,26 @@ class AuditLogControllerTest {
                 "details_timestamp", Instant.now().minusSeconds(70));
 
         AuditLog auditLog1 = new AuditLog(
+                42L,
+                Instant.now().truncatedTo(ChronoUnit.SECONDS),
                 "test-user1",
                 studyId,
                 "test-action1",
                 Instant.now().minusSeconds(10).truncatedTo(ChronoUnit.SECONDS))
                 .setDetails(details)
-                .setActionState(AuditLog.ActionState.success);
+                .setActionState(AuditLog.ActionState.success)
+                .setUserName("Test User1");
 
         AuditLog auditLog2 = new AuditLog(
+                69L,
+                Instant.now().truncatedTo(ChronoUnit.SECONDS),
                 "test-user2",
                 studyId,
                 "test-action2",
                 Instant.now().minusSeconds(50).truncatedTo(ChronoUnit.SECONDS))
                 .setDetails(details)
-                .setActionState(AuditLog.ActionState.success);
+                .setActionState(AuditLog.ActionState.success)
+                .setUserName("Test User2");
 
         when(auditLogRepository.listAuditLog(anyLong()))
                 .thenAnswer(invocation -> Stream.of(auditLog1, auditLog2));
@@ -130,15 +135,17 @@ class AuditLogControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].id").value(42))
                 .andExpect(jsonPath("$[0].studyId").value(studyId))
                 .andExpect(jsonPath("$[0].userId").value("test-user1"))
+                .andExpect(jsonPath("$[0].userName").value("Test User1"))
                 .andExpect(jsonPath("$[0].action").value("test-action1"))
                 .andExpect(jsonPath("$[0].actionState").value("success"))
                 .andExpect(jsonPath("$[0].detail_state").value(Boolean.TRUE))
                 .andExpect(jsonPath("$[0].detail_text").value("This is an important test"))
                 .andExpect(jsonPath("$[0].userRoles[0]").value("admin"))
                 .andExpect(jsonPath("$[0].userRoles[1]").value("viewer"))
-                .andExpect(jsonPath("$[0].user_role").value(1));
+                .andExpect(jsonPath("$[0].created").exists());
     }
 
 }

--- a/studymanager/src/test/java/io/redlink/more/studymanager/repository/AuditLogRepositoryTest.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/repository/AuditLogRepositoryTest.java
@@ -42,6 +42,7 @@ class AuditLogRepositoryTest {
     @DisplayName("Create AuditLog")
     void testInsert() {
         String userId = "test-user";
+        String userName = "Test User";
         Long studyId = 1L;
         String actionId = "test-action";
         Instant timestamp = Instant.now().minusSeconds(10).truncatedTo(ChronoUnit.SECONDS);
@@ -66,7 +67,8 @@ class AuditLogRepositoryTest {
                 actionId,
                 timestamp)
                 .setDetails(details)
-                .setActionState(AuditLog.ActionState.success);
+                .setActionState(AuditLog.ActionState.success)
+                .setUserName(userName);
 
         AuditLog auditLogResonse = auditLogRepository.insert(auditLog);
 
@@ -77,6 +79,7 @@ class AuditLogRepositoryTest {
         assertThat(auditLogResonse.getCreated()).isBetween(timestamp, Instant.now().plusMillis(1));
         //assert the values of the AuditLog
         assertThat(auditLogResonse.getUserId()).isEqualTo(userId);
+        assertThat(auditLogResonse.getUserName()).isEqualTo(userName);
         assertThat(auditLogResonse.getStudyId()).isEqualTo(studyId);
         assertThat(auditLogResonse.getAction()).isEqualTo(actionId);
         assertThat(auditLogResonse.getTimestamp()).isEqualTo(timestamp);


### PR DESCRIPTION
Changes

* fix: configuration is now under `more.audit` (was under `audit`). Now the default in the application.yaml maps with the properties class
* fix: created is now mapped from the internal model to the webservice model. Extended UnitTest for created and id
* feature: the `username` of the token is now stored in the audit log and mapped to the web service. Added a user_name column to the database