### PR TITLE
Add study_roles information to the audit log

### DIFF
--- a/studymanager/src/main/java/io/redlink/more/studymanager/audit/AuditAspect.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/audit/AuditAspect.java
@@ -4,10 +4,13 @@ import io.redlink.more.studymanager.api.v1.model.StudyDTO;
 import io.redlink.more.studymanager.model.AuthenticatedUser;
 import io.redlink.more.studymanager.model.PlatformRole;
 import io.redlink.more.studymanager.model.Study;
+import io.redlink.more.studymanager.model.StudyRole;
 import io.redlink.more.studymanager.model.audit.AuditLog;
 import io.redlink.more.studymanager.properties.AuditProperties;
+import io.redlink.more.studymanager.repository.AuditLogRepository;
 import io.redlink.more.studymanager.service.AuditService;
 import io.redlink.more.studymanager.service.OAuth2AuthenticationService;
+import io.redlink.more.studymanager.service.StudyService;
 import io.redlink.more.studymanager.utils.MapperUtils;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
@@ -19,6 +22,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -28,14 +32,17 @@ public class AuditAspect {
     private final AuditProperties auditProperties;
     private final AuditService auditService;
     private final OAuth2AuthenticationService authService;
+    private final StudyService studyService;
 
     public AuditAspect(
             AuditProperties auditProperties,
             AuditService auditService,
-            OAuth2AuthenticationService authService) {
+            OAuth2AuthenticationService authService,
+            StudyService studyService) {
         this.auditService = auditService;
         this.authService = authService;
         this.auditProperties = auditProperties;
+        this.studyService = studyService;
     }
         @AfterThrowing(pointcut = "@annotation(Audited)", throwing = "e")
         public void recordException(JoinPoint joinPoint, Throwable e){
@@ -82,6 +89,7 @@ public class AuditAspect {
         //finally set some additional information (if available)
         auditLog.getDetails().putAll(parameters);
         auditLog.getDetails().put("user_roles", user.roles().stream().map(PlatformRole::name).toList());
+        auditLog.getDetails().put("study_roles", studyService.getStudyRoles(studyId, user.id()).stream().map(StudyRole::name).toList());
         if(e != null){
             auditLog.getDetails().put("exception", e.getClass().getName());
         }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/AuditlogTransformer.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/AuditlogTransformer.java
@@ -20,8 +20,15 @@ public final class AuditlogTransformer {
 
     public static AuditLogEntryDTO toAuditlogEntryDTO_V1(AuditLog auditLog) {
         Map<String,Object> details = new HashMap<>(auditLog.getDetails());
+        //Both user_roles and study_roles are stored in the details, but exposed as special attribute in the DTO
         List<String> userRoles = Optional.ofNullable(
                 details.remove("user_roles"))
+                .filter(it -> it instanceof List)
+                .map(List.class::cast)
+                .map(it -> it.stream().map(Objects::toString).toList()
+            ).orElse(null);
+        List<String> studyRoles = Optional.ofNullable(
+                        details.remove("study_roles"))
                 .filter(it -> it instanceof List)
                 .map(List.class::cast)
                 .map(it -> it.stream().map(Objects::toString).toList()
@@ -31,7 +38,8 @@ public final class AuditlogTransformer {
                 .created(auditLog.getCreated())
                 .studyId(auditLog.getStudyId())
                 .userId(auditLog.getUserId())
-                .userRoles(userRoles) //the user roles as parsed from the details
+                .userRoles(userRoles)
+                .studyRoles(studyRoles)
                 .userName(auditLog.getUserName())
                 .timestamp(auditLog.getTimestamp())
                 .action(auditLog.getAction())

--- a/studymanager/src/main/java/io/redlink/more/studymanager/service/StudyService.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/service/StudyService.java
@@ -200,6 +200,10 @@ public class StudyService {
         );
     }
 
+    public Set<StudyRole> getStudyRoles(Long studyId, String userId){
+        return aclRepository.getRoles(studyId, userId);
+    }
+
     public Optional<Duration> getStudyDuration(Long studyId) {
         return studyRepository.getById(studyId)
                 .map(Study::getDuration);

--- a/studymanager/src/main/resources/openapi/StudyManagerAPI.yaml
+++ b/studymanager/src/main/resources/openapi/StudyManagerAPI.yaml
@@ -2232,6 +2232,12 @@ components:
           readOnly: true
         userRoles:
           description: |
+            An array of the user's roles on the MORE server at the moment of the recorded activity.
+          type: array
+          items:
+            type: string
+        studyRoles:
+          description: |
             An array of the user's study roles at the moment of the recorded activity.
           type: array
           items:

--- a/studymanager/src/test/java/io/redlink/more/studymanager/audit/AuditAspectTest.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/audit/AuditAspectTest.java
@@ -8,6 +8,7 @@ import io.redlink.more.studymanager.model.audit.AuditLog;
 import io.redlink.more.studymanager.properties.AuditProperties;
 import io.redlink.more.studymanager.service.AuditService;
 import io.redlink.more.studymanager.service.OAuth2AuthenticationService;
+import io.redlink.more.studymanager.service.StudyService;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.Signature;
 import org.aspectj.lang.reflect.CodeSignature;
@@ -35,11 +36,13 @@ public class AuditAspectTest {
     AuditService auditService = Mockito.mock(AuditService.class);
     OAuth2AuthenticationService authService = Mockito.mock(OAuth2AuthenticationService.class);
     AuthenticatedUser authUser = Mockito.mock(AuthenticatedUser.class);
+    StudyService studyService = Mockito.mock(StudyService.class);
 
     AuditAspect auditAspect = new AuditAspect(
             new AuditProperties(EnumSet.of(Study.Status.ACTIVE, Study.Status.PAUSED, Study.Status.CLOSED), -1L),
             auditService,
-            authService);
+            authService,
+            studyService);
 
     @Before
     public void setup() {

--- a/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/AuditLogControllerTest.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/AuditLogControllerTest.java
@@ -94,6 +94,7 @@ class AuditLogControllerTest {
 
         Map<String,Object> details = Map.of(
                 "user_roles", List.of("admin", "viewer"),
+                "study_roles", List.of("STUDY_VIEWER", "STUDY_OPERATOR"),
                 "detail_state", Boolean.TRUE,
                 "detail_integer", 42,
                 "detail_number", 3.1415,
@@ -145,6 +146,8 @@ class AuditLogControllerTest {
                 .andExpect(jsonPath("$[0].detail_text").value("This is an important test"))
                 .andExpect(jsonPath("$[0].userRoles[0]").value("admin"))
                 .andExpect(jsonPath("$[0].userRoles[1]").value("viewer"))
+                .andExpect(jsonPath("$[0].studyRoles[0]").value("STUDY_VIEWER"))
+                .andExpect(jsonPath("$[0].studyRoles[1]").value("STUDY_OPERATOR"))
                 .andExpect(jsonPath("$[0].created").exists());
     }
 

--- a/studymanager/src/test/java/io/redlink/more/studymanager/repository/AuditLogRepositoryTest.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/repository/AuditLogRepositoryTest.java
@@ -54,6 +54,7 @@ class AuditLogRepositoryTest {
 
         Instant detailsTimestamp = timestamp.minusSeconds(10);
         Map<String,Object> details = Map.of(
+                "user_roles", Arrays.asList("test-role1", "test-role2"),
                 "detail_state", Boolean.TRUE,
                 "detail_integer", 42,
                 "detail_number", 3.1415,
@@ -87,6 +88,7 @@ class AuditLogRepositoryTest {
         //assert Details
         assertThat(auditLogResonse.getDetails()).isNotNull();
         assertThat(auditLogResonse.getDetails().keySet()).isEqualTo(details.keySet());
+        assertThat(auditLogResonse.getDetails().get("user_roles")).isEqualTo(Arrays.asList("test-role1", "test-role2"));
         assertThat(auditLogResonse.getDetails().get("detail_state")).isEqualTo(Boolean.TRUE);
         assertThat(auditLogResonse.getDetails().get("detail_integer")).isEqualTo(42);
         assertThat(auditLogResonse.getDetails().get("detail_number")).isEqualTo(3.1415);


### PR DESCRIPTION
Users do not only have a role for the MORE system, but roles for the specific study. This extension to the audit log now also reports the study roles of the user at the time the action was logged