### PR TITLE
prehab2rehab #421: Cron Job to create OccurredObservations

### DIFF
--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/Study.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/Study.java
@@ -12,6 +12,8 @@ import io.redlink.more.studymanager.model.scheduler.Duration;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.Set;
 
 public class Study {
@@ -61,6 +63,7 @@ public class Study {
                     "No enum constant " + Status.class.getCanonicalName() + " with value " + value
             );
         }
+        public static Set<Status> ACTIVE_STATES = Collections.unmodifiableSet(EnumSet.of(Status.PREVIEW, Status.ACTIVE));
     }
 
     public Long getStudyId() {

--- a/studymanager/src/main/java/io/redlink/more/studymanager/repository/StudyRepository.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/repository/StudyRepository.java
@@ -19,6 +19,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -44,6 +47,7 @@ public class StudyRepository {
                     "WHERE study_id = ?";
     private static final String LIST_STUDIES_ORDER_BY_MODIFIED_DESC = "SELECT * FROM studies ORDER BY modified DESC";
     private static final String LIST_STUDIES_BY_STATUS = "SELECT * FROM studies WHERE status = ?::study_state";
+    private static final String LIST_STUDIES_BY_STATES = "SELECT * FROM studies WHERE status = ANY(?::study_state[])";
     private static final String LIST_STUDY_BY_ACL =
             "SELECT studies.*, acl.user_roles " +
             "FROM studies " +
@@ -201,6 +205,14 @@ public class StudyRepository {
 
     public List<Study> listStudiesByStatus(Study.Status status) {
         return template.query(LIST_STUDIES_BY_STATUS, getStudyRowMapper(), status.getValue());
+    }
+    public Stream<Study> listStudiesByStates(Iterable<Study.Status> states) {
+        return template.queryForStream(
+                LIST_STUDIES_BY_STATES,
+                getStudyRowMapper(),
+                //cast to object as this is no vararg but a single parameter that happens to be an array
+                (Object) StreamSupport.stream(states.spliterator(),false)
+                        .map(Study.Status::getValue).toArray(String[]::new));
     }
 
     public boolean hasState(long studyId, Collection<Study.Status> allowedStates){

--- a/studymanager/src/main/java/io/redlink/more/studymanager/scheduling/UpsertOccurredObservationsCron.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/scheduling/UpsertOccurredObservationsCron.java
@@ -8,66 +8,64 @@
  */
 package io.redlink.more.studymanager.scheduling;
 
-import io.redlink.more.studymanager.action.ActionService;
-import io.redlink.more.studymanager.core.exception.SchedulingException;
-import io.redlink.more.studymanager.core.factory.TriggerFactory;
-import io.redlink.more.studymanager.core.io.Parameters;
-import io.redlink.more.studymanager.core.io.TriggerResult;
-import io.redlink.more.studymanager.core.sdk.MoreTriggerSDK;
 import io.redlink.more.studymanager.model.Participant;
 import io.redlink.more.studymanager.model.Study;
-import io.redlink.more.studymanager.model.Trigger;
 import io.redlink.more.studymanager.model.timeline.ObservationTimelineEvent;
-import io.redlink.more.studymanager.sdk.MoreSDK;
 import io.redlink.more.studymanager.service.*;
 import io.redlink.more.studymanager.utils.LoggingUtils;
-import org.quartz.Job;
-import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
 
 import java.time.Instant;
-import java.time.LocalTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
-public class UpsertOccurredObservationsJob implements Job {
+@Component
+public class UpsertOccurredObservationsCron {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(UpsertOccurredObservationsJob.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(UpsertOccurredObservationsCron.class);
 
-    @Autowired
-    private StudyService studyService;
-    @Autowired
-    private ParticipantService participantService;
-    @Autowired
-    private OccurredObservationService occurredObservationService;
-    @Autowired
-    private CalendarService calendarService;
+    private final StudyService studyService;
+    private final ParticipantService participantService;
+    private final OccurredObservationService occurredObservationService;
+    private final CalendarService calendarService;
 
-    @Override
-    public void execute(JobExecutionContext context) throws JobExecutionException {
+
+    UpsertOccurredObservationsCron(
+            StudyService studyService,
+            ParticipantService participantService,
+            OccurredObservationService occurredObservationService,
+            CalendarService calendarService
+    ) {
+        this.studyService = studyService;
+        this.participantService = participantService;
+        this.occurredObservationService = occurredObservationService;
+        this.calendarService = calendarService;
+    }
+
+    @Scheduled(cron="0 */5 * * * ?") //every 5min
+    protected void upsertOccurredObservations(){
+        //list all active studies
+        studyService.getStudiesByStates(Study.Status.ACTIVE_STATES)
+                .forEach(this::upsertOccurredObservations);
+    }
+
+    private void upsertOccurredObservations(Study study) {
         try (var ctx = LoggingUtils.createContext()) {
-            Study study = studyService.getStudy(
-                    context.getJobDetail().getJobDataMap().getLong("studyId"),
-                    null
-            ).orElse(null);
-            if(study == null) {
+            if(study == null || !Study.Status.ACTIVE_STATES.contains(study.getStudyState())) {
                 return; //nothing to do
             }
             ctx.putStudy(study);
             List<Participant> participants = participantService.listParticipants(study.getStudyId());
             Instant lastOccurredObservation = occurredObservationService.getLatestStartTime(study.getStudyId());
-            //NOTE: use now + 2min for current because:
-            //  1. we truncatedTo(ChronoUnit.MINUTES) all Instants
+            //NOTE: use now + 1min for current because:
+            //  1. we truncatedTo(ChronoUnit.MINUTES) all Instants and
             //  2. we check with start.isBefore(current)
             // doing so will include all Observations that start in the current minute
-            Instant current = Instant.now().plus(2, ChronoUnit.MINUTES).truncatedTo(ChronoUnit.MINUTES);
+            Instant current = Instant.now().plus(1, ChronoUnit.MINUTES).truncatedTo(ChronoUnit.MINUTES);
+            LOGGER.debug("Upsert Occurred Observations for Study(id: {}) and timeperiode(start:{}, end:{})", study.getStudyId(), lastOccurredObservation, current);
 
             for(Participant participant : participants) {
                 ctx.putParticipant(participant);
@@ -76,7 +74,7 @@ public class UpsertOccurredObservationsJob implements Job {
                 for(ObservationTimelineEvent event : timeline.observationTimelineEvents()){
                     var start = event.start().truncatedTo(ChronoUnit.MINUTES);
                     if((lastOccurredObservation == null || start.isAfter(lastOccurredObservation)) && start.isBefore(current)){
-                        LOGGER.debug("upsert occurred observation for study: {}, observation: {}, participant: {}, start: {}, end: {}",
+                        LOGGER.trace("upsert occurred observation for study: {}, observation: {}, participant: {}, start: {}, end: {}",
                                 study.getStudyId(), event.observationId(), participant.getParticipantId(), event.start(), event.end());
                         occurredObservationService.upsert(study.getStudyId(), event.observationId(), participant.getParticipantId(), event.start(), event.end());
                     } //else outside of time range ... ignore

--- a/studymanager/src/main/java/io/redlink/more/studymanager/scheduling/UpsertOccurredObservationsJob.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/scheduling/UpsertOccurredObservationsJob.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Elastic License 2.0.
+ */
+package io.redlink.more.studymanager.scheduling;
+
+import io.redlink.more.studymanager.action.ActionService;
+import io.redlink.more.studymanager.core.exception.SchedulingException;
+import io.redlink.more.studymanager.core.factory.TriggerFactory;
+import io.redlink.more.studymanager.core.io.Parameters;
+import io.redlink.more.studymanager.core.io.TriggerResult;
+import io.redlink.more.studymanager.core.sdk.MoreTriggerSDK;
+import io.redlink.more.studymanager.model.Participant;
+import io.redlink.more.studymanager.model.Study;
+import io.redlink.more.studymanager.model.Trigger;
+import io.redlink.more.studymanager.model.timeline.ObservationTimelineEvent;
+import io.redlink.more.studymanager.sdk.MoreSDK;
+import io.redlink.more.studymanager.service.*;
+import io.redlink.more.studymanager.utils.LoggingUtils;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.Instant;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class UpsertOccurredObservationsJob implements Job {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UpsertOccurredObservationsJob.class);
+
+    @Autowired
+    private StudyService studyService;
+    @Autowired
+    private ParticipantService participantService;
+    @Autowired
+    private OccurredObservationService occurredObservationService;
+    @Autowired
+    private CalendarService calendarService;
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        try (var ctx = LoggingUtils.createContext()) {
+            Study study = studyService.getStudy(
+                    context.getJobDetail().getJobDataMap().getLong("studyId"),
+                    null
+            ).orElse(null);
+            if(study == null) {
+                return; //nothing to do
+            }
+            ctx.putStudy(study);
+            List<Participant> participants = participantService.listParticipants(study.getStudyId());
+            Instant lastOccurredObservation = occurredObservationService.getLatestStartTime(study.getStudyId());
+            //NOTE: use now + 2min for current because:
+            //  1. we truncatedTo(ChronoUnit.MINUTES) all Instants
+            //  2. we check with start.isBefore(current)
+            // doing so will include all Observations that start in the current minute
+            Instant current = Instant.now().plus(2, ChronoUnit.MINUTES).truncatedTo(ChronoUnit.MINUTES);
+
+            for(Participant participant : participants) {
+                ctx.putParticipant(participant);
+                //NOTE: from, to are currently not supported
+                var timeline = calendarService.getTimeline(study, participant, null, null, null, null);
+                for(ObservationTimelineEvent event : timeline.observationTimelineEvents()){
+                    var start = event.start().truncatedTo(ChronoUnit.MINUTES);
+                    if((lastOccurredObservation == null || start.isAfter(lastOccurredObservation)) && start.isBefore(current)){
+                        LOGGER.debug("upsert occurred observation for study: {}, observation: {}, participant: {}, start: {}, end: {}",
+                                study.getStudyId(), event.observationId(), participant.getParticipantId(), event.start(), event.end());
+                        occurredObservationService.upsert(study.getStudyId(), event.observationId(), participant.getParticipantId(), event.start(), event.end());
+                    } //else outside of time range ... ignore
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Cannot execute Trigger-Job: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/studymanager/src/main/java/io/redlink/more/studymanager/service/CalendarService.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/service/CalendarService.java
@@ -51,11 +51,6 @@ public class CalendarService {
     public StudyTimeline getTimeline(Long studyId, Integer participantId, Integer studyGroupId, Instant referenceDate, LocalDate from, LocalDate to) {
         final Study study = studyService.getStudy(studyId, null)
                 .orElseThrow(() -> NotFoundException.Study(studyId));
-        final Range<LocalDate> studyRange = Range.of(
-                Objects.requireNonNullElse(study.getStartDate(), study.getPlannedStartDate()),
-                Objects.requireNonNullElse(study.getEndDate(), study.getPlannedEndDate()),
-                LocalDate::compareTo
-        );
         final Participant participant;
         if (participantId != null) {
             participant = Optional.ofNullable(participantService.getParticipant(studyId, participantId))
@@ -63,6 +58,15 @@ public class CalendarService {
         } else {
             participant = null;
         }
+        return getTimeline(study, participant, studyGroupId, referenceDate, from, to);
+    }
+
+    public StudyTimeline getTimeline(Study study, Participant participant, Integer studyGroupId, Instant referenceDate, LocalDate from, LocalDate to) {
+        final Range<LocalDate> studyRange = Range.of(
+                Objects.requireNonNullElse(study.getStartDate(), study.getPlannedStartDate()),
+                Objects.requireNonNullElse(study.getEndDate(), study.getPlannedEndDate()),
+                LocalDate::compareTo
+        );
 
         /* Priority of Parameters:
          * participantStart:
@@ -96,16 +100,16 @@ public class CalendarService {
             effectiveGroup = studyGroupId;
         }
 
-        final List<Observation> observations = observationService.listObservationsForGroup(studyId, effectiveGroup);
-        final List<Intervention> interventions = interventionService.listInterventionsForGroup(studyId, effectiveGroup);
+        final List<Observation> observations = observationService.listObservationsForGroup(study.getStudyId(), effectiveGroup);
+        final List<Intervention> interventions = interventionService.listInterventionsForGroup(study.getStudyId(), effectiveGroup);
 
         // Shift the effective study-start if the participant would miss a relative observation
         final LocalDate firstDayInStudy = SchedulerUtils.alignStartDateToSignupInstant(participantStart, observations);
 
         // now how long does the study run?
         final Duration studyDuration = Optional.ofNullable(effectiveGroup)
-                .flatMap(eg -> studyService.getStudyDuration(studyId, eg))
-                .or(() -> studyService.getStudyDuration(studyId))
+                .flatMap(eg -> studyService.getStudyDuration(study.getStudyId(), eg))
+                .or(() -> Optional.of(study.getDuration()))
                 .or(() -> Optional.of(new Duration()
                         .setValue(
                                 (int) ChronoUnit.DAYS.between(
@@ -114,7 +118,7 @@ public class CalendarService {
                                 ) + 1)
                         .setUnit(Duration.Unit.DAY)
                 ))
-                .orElseThrow(() -> NotFoundException.Study(studyId));
+                .orElseThrow(() -> NotFoundException.Study(study.getStudyId()));
 
         final LocalDate lastDayInStudy = firstDayInStudy
                 .plus(
@@ -143,13 +147,13 @@ public class CalendarService {
                                 )
                                 .stream()
                                 // Disabled client-side filter for now...
-                                // .filter(filterWindow::isOverlappedBy)
+                                //Ï .filter(filterWindow::isOverlappedBy)
                                 .map(e -> ObservationTimelineEvent.fromObservation(o, e.getMinimum(), e.getMaximum()))
                         )
                         .toList(),
                 interventions.stream()
                         .map(intervention -> {
-                            Trigger trigger = interventionService.getTriggerByIds(studyId, intervention.getInterventionId());
+                            Trigger trigger = interventionService.getTriggerByIds(study.getStudyId(), intervention.getInterventionId());
                             return SchedulerUtils.parseToInterventionSchedules(
                                             trigger,
                                             effectiveRange.getMinimum(),

--- a/studymanager/src/main/java/io/redlink/more/studymanager/service/InterventionService.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/service/InterventionService.java
@@ -156,7 +156,7 @@ public class InterventionService {
     }
 
     public void alignInterventionsWithStudyState(Study study) {
-        if (EnumSet.of(Study.Status.ACTIVE, Study.Status.PREVIEW).contains(study.getStudyState())) {
+        if (Study.Status.ACTIVE_STATES.contains(study.getStudyState())) {
             activateInterventionsFor(study);
         } else {
             deactivateInterventionsFor(study);

--- a/studymanager/src/main/java/io/redlink/more/studymanager/service/ObservationService.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/service/ObservationService.java
@@ -89,7 +89,7 @@ public class ObservationService {
     }
 
     public void alignObservationsWithStudyState(Study study){
-        if (EnumSet.of(Study.Status.ACTIVE, Study.Status.PREVIEW).contains(study.getStudyState()))
+        if (Study.Status.ACTIVE_STATES.contains(study.getStudyState()))
             activateObservationsFor(study);
         else deactivateObservationsFor(study);
     }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/service/OccurredObservationService.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/service/OccurredObservationService.java
@@ -10,7 +10,6 @@ package io.redlink.more.studymanager.service;
 
 import io.redlink.more.studymanager.model.OccurredObservation;
 import io.redlink.more.studymanager.repository.OccurredObservationRepository;
-import io.redlink.more.studymanager.sdk.MoreSDK;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -22,15 +21,11 @@ public class OccurredObservationService {
 
     private final OccurredObservationRepository repository;
 
-    private final MoreSDK sdk;
-
     private static final EnumSet<OccurredObservation.DataState> COMPLETED_DATA_STATES = EnumSet.of(OccurredObservation.DataState.COMPLETE);
     private static final EnumSet<OccurredObservation.DataState> ACTIVE_DATA_STATES = EnumSet.complementOf(COMPLETED_DATA_STATES);
 
-    public OccurredObservationService(OccurredObservationRepository repository,
-                                      MoreSDK sdk) {
+    public OccurredObservationService(OccurredObservationRepository repository) {
         this.repository = repository;
-        this.sdk = sdk;
     }
 
     public OccurredObservation upsert(long studyId, int observationId, int participantId, Instant start, Instant end){

--- a/studymanager/src/main/java/io/redlink/more/studymanager/service/StudyService.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/service/StudyService.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
+
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -220,4 +222,15 @@ public class StudyService {
                 // ... of fallback to the study-duration if not set.
                 .or(() -> getStudyDuration(studyId));
     }
+
+    /**
+     * Provides a stream over all studies with the parsed states
+     * @param states the states
+     * @return the studies with the parsed states. An empty Stream is <code>null</code> was
+     * parsed or no Studies with the requested states are present
+     */
+    public Stream<Study> getStudiesByStates(Iterable<Study.Status> states) {
+        return states == null ? Stream.empty() : studyRepository.listStudiesByStates(states);
+    }
+
 }

--- a/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/CalendarControllerTest.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/CalendarControllerTest.java
@@ -64,7 +64,7 @@ class CalendarControllerTest {
         LocalDate from = LocalDate.of(2024, 2, 1);
         LocalDate to = LocalDate.of(2024, 5, 1);
 
-        when(service.getTimeline(any(), any(), any(), any(Instant.class), any(LocalDate.class), any(LocalDate.class)))
+        when(service.getTimeline(any(Long.class), any(Integer.class), any(), any(Instant.class), any(LocalDate.class), any(LocalDate.class)))
                 .thenAnswer(invocationOnMock -> {
                     return new StudyTimeline(
                             referenceDate,

--- a/studymanager/src/test/java/io/redlink/more/studymanager/repository/StudyRepositoryTest.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/repository/StudyRepositoryTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -178,6 +179,32 @@ class StudyRepositoryTest {
         assertTrue(studyRepository.hasState(study.getStudyId(), statusSet1));
         assertFalse(studyRepository.hasState(study.getStudyId(), statusSet2));
         assertFalse(studyRepository.hasState(study.getStudyId(), statusSet3));
+    }
+
+    @Test
+    @DisplayName("List Studies by States")
+    void testListStudiesByStates(){
+        Set<Study.Status> statusSet1 = Set.of(Study.Status.ACTIVE, Study.Status.DRAFT);
+        Set<Study.Status> statusSet2 = Set.of(Study.Status.CLOSED);
+        Set<Study.Status> statusSet3 = Collections.emptySet();
+
+        Study ativeStudy = studyRepository.insert(new Study().setTitle("Active Study").setContact(new Contact().setPerson("test").setEmail("test")));
+        studyRepository.setStateById(ativeStudy.getStudyId(), Study.Status.ACTIVE);
+        Study previewStudy = studyRepository.insert(new Study().setTitle("Preview Study").setContact(new Contact().setPerson("test").setEmail("test")));
+        studyRepository.setStateById(previewStudy.getStudyId(), Study.Status.PREVIEW);
+        Study pausedStudy = studyRepository.insert(new Study().setTitle("Paused Study").setContact(new Contact().setPerson("test").setEmail("test")));
+        studyRepository.setStateById(pausedStudy.getStudyId(), Study.Status.PAUSED);
+        Study closedStudy = studyRepository.insert(new Study().setTitle("Closed Study").setContact(new Contact().setPerson("test").setEmail("test")));
+        studyRepository.setStateById(closedStudy.getStudyId(), Study.Status.CLOSED);
+        Study draftStudy = studyRepository.insert(new Study().setTitle("Draft Study").setContact(new Contact().setPerson("test").setEmail("test")));
+        Study activeStudy2 = studyRepository.insert(new Study().setTitle("Active Study2").setContact(new Contact().setPerson("test").setEmail("test")));
+        studyRepository.setStateById(activeStudy2.getStudyId(), Study.Status.ACTIVE);
+
+        assertThat(studyRepository.listStudiesByStatus(Study.Status.CLOSED).stream().map(Study::getStudyId).toList()).containsExactlyInAnyOrder(closedStudy.getStudyId());
+        assertThat(studyRepository.listStudiesByStatus(Study.Status.ACTIVE).stream().map(Study::getStudyId).toList()).containsExactlyInAnyOrder(ativeStudy.getStudyId(), activeStudy2.getStudyId());
+
+        assertThat(studyRepository.listStudiesByStates(Study.Status.ACTIVE_STATES).map(Study::getStudyId).toList()).containsExactlyInAnyOrder(ativeStudy.getStudyId(), activeStudy2.getStudyId(), previewStudy.getStudyId());
+        assertThat(studyRepository.listStudiesByStates(EnumSet.of(Study.Status.PAUSED, Study.Status.DRAFT)).map(Study::getStudyId).toList()).containsExactlyInAnyOrder(pausedStudy.getStudyId(), draftStudy.getStudyId());
     }
 
 

--- a/studymanager/src/test/java/io/redlink/more/studymanager/scheduling/UpsertOccurredObservationsCronTest.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/scheduling/UpsertOccurredObservationsCronTest.java
@@ -1,0 +1,281 @@
+package io.redlink.more.studymanager.scheduling;
+
+import io.redlink.more.studymanager.model.OccurredObservation;
+import io.redlink.more.studymanager.model.Participant;
+import io.redlink.more.studymanager.model.Study;
+import io.redlink.more.studymanager.model.timeline.ObservationTimelineEvent;
+import io.redlink.more.studymanager.model.timeline.StudyTimeline;
+import io.redlink.more.studymanager.service.CalendarService;
+import io.redlink.more.studymanager.service.OccurredObservationService;
+import io.redlink.more.studymanager.service.ParticipantService;
+import io.redlink.more.studymanager.service.StudyService;
+import org.apache.commons.lang3.Range;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyIterable;
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+public class UpsertOccurredObservationsCronTest {
+
+    @Mock
+    StudyService studyService;
+
+    @Mock
+    ParticipantService participantService;
+
+    @Mock
+    OccurredObservationService occurredObservationService;
+
+    @Mock
+    CalendarService calendarService;
+
+    @InjectMocks
+    UpsertOccurredObservationsCron upsertOccurredObservationsCron;
+
+
+    Instant lastOoTimestamp;
+    Instant testNowTimestamp;
+
+    @BeforeEach
+    public void beforeEach() {
+        testNowTimestamp = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+        lastOoTimestamp = testNowTimestamp.minus(5, ChronoUnit.MINUTES);
+    }
+
+    @Test
+    @DisplayName("Test upsert of occurred observation")
+    public void testUpsert() {
+
+        Study study1 = new Study()
+                .setStudyId(1L)
+                .setTitle("Study 1")
+                .setStudyState(Study.Status.ACTIVE);
+        Participant study1Par1 = new Participant()
+                .setParticipantId(1)
+                .setAlias("Study 1 Participant 1");
+        Participant study1Par2 = new Participant()
+                .setParticipantId(2)
+                .setAlias("Study 1 Participant 2");
+        Participant study1Par3 = new Participant()
+                .setParticipantId(3)
+                .setAlias("Study 1 Participant 3");
+
+        Study study2 = new Study()
+                .setStudyId(2L)
+                .setTitle("Study 2")
+                .setStudyState(Study.Status.PREVIEW);
+        Participant study2Par1 = new Participant()
+                .setParticipantId(1)
+                .setAlias("Study 2 Participant 1");
+        Participant study2Par2 = new Participant()
+                .setParticipantId(2)
+                .setAlias("Study 2 Participant 2");
+        //Mock the iteration over all active studies
+        when(studyService.getStudiesByStates(anyIterable()))
+                .thenReturn(Stream.of(study1, study2));
+
+        //Mock getting the participants for all active studies
+        when(participantService.listParticipants(study1.getStudyId()))
+                .thenReturn(List.of(study1Par1, study1Par2, study1Par3));
+        when(participantService.listParticipants(study2.getStudyId()))
+                .thenReturn(List.of(study2Par1, study2Par2));
+
+        when(calendarService.getTimeline(any(Study.class), any(Participant.class), any(), any(), any(), any()))
+                .thenAnswer(invocationOnMock -> {
+                    Long studyId = invocationOnMock.getArgument(0, Study.class).getStudyId();
+                    Integer participantId = invocationOnMock.getArgument(1, Participant.class).getParticipantId();
+                    //Mock Timeline for Study 1 Participant 1
+                    // ... we expect a single occurred Observation for observation 2
+                    if (Objects.equals(studyId, study1.getStudyId()) && Objects.equals(participantId, study1Par1.getParticipantId())) {
+                        return createStudytimeline(List.of(
+                                createObservationTimelineEvent(
+                                        1,
+                                        //this event was activated at the end of the previous run - should be ignored
+                                        lastOoTimestamp,
+                                        lastOoTimestamp.plus(30, ChronoUnit.MINUTES)
+                                ),
+                                createObservationTimelineEvent(
+                                        2,
+                                        //this event was activated after the previous run!
+                                        lastOoTimestamp.plus(1, ChronoUnit.MINUTES),
+                                        lastOoTimestamp.plus(31, ChronoUnit.MINUTES)
+                                ),
+                                createObservationTimelineEvent(
+                                        3,
+                                        //this event is in the future - should be ignored
+                                        testNowTimestamp.plus(2, ChronoUnit.MINUTES),
+                                        lastOoTimestamp.plus(31, ChronoUnit.MINUTES)
+                                )));
+                    } else if(Objects.equals(studyId, study1.getStudyId()) && Objects.equals(participantId, study1Par2.getParticipantId())) {
+                        //Mock Timeline for Study 1 Participant 2
+                        // ... we expect no occurred Observation
+                        return createStudytimeline(List.of(
+                                createObservationTimelineEvent(
+                                        1,
+                                        //this event was activated at the end of the previous run - should be ignored
+                                        lastOoTimestamp,
+                                        testNowTimestamp.plus(14, ChronoUnit.MINUTES)
+                                ),
+                                createObservationTimelineEvent(
+                                        3,
+                                        //this event was activated before the previous run!
+                                        lastOoTimestamp.minus(1, ChronoUnit.MINUTES),
+                                        lastOoTimestamp.plus(29, ChronoUnit.MINUTES)
+                                )));
+                    } else if(Objects.equals(studyId, study1.getStudyId()) && Objects.equals(participantId, study1Par3.getParticipantId())) {
+                        //Mock Timeline for Study 1 Participant 3
+                        // ... we expect two occurred Observation (observation 1 and 3)
+                        return createStudytimeline(List.of(
+                                createObservationTimelineEvent(
+                                        1,
+                                        //this event was activated after the end of the previous run - should be included
+                                        testNowTimestamp.minus(1, ChronoUnit.MINUTES),
+                                        testNowTimestamp.plus(14, ChronoUnit.MINUTES)
+                                ),
+                                createObservationTimelineEvent(
+                                        3,
+                                        //this event was activated before the previous run!
+                                        lastOoTimestamp.plus(1, ChronoUnit.MINUTES),
+                                        lastOoTimestamp.plus(31, ChronoUnit.MINUTES)
+                                )));
+                    } else if(Objects.equals(studyId, study2.getStudyId()) && Objects.equals(participantId, study2Par1.getParticipantId())) {
+                        //Mock Timeline for Study 2 Participant 1
+                        // ... we expect one occurred Observation (observation 1)
+                        return createStudytimeline(List.of(
+                                createObservationTimelineEvent(
+                                        1,
+                                        //this event was activated after the end of the previous run - should be ignored
+                                        testNowTimestamp.minus(1, ChronoUnit.MINUTES),
+                                        testNowTimestamp.plus(14, ChronoUnit.MINUTES)
+                                ),
+                                createObservationTimelineEvent(
+                                        2,
+                                        //this event is one day in the past
+                                        lastOoTimestamp.plus(1, ChronoUnit.MINUTES).minus(1, ChronoUnit.DAYS),
+                                        lastOoTimestamp.plus(31, ChronoUnit.MINUTES).minus(1, ChronoUnit.DAYS)
+                                )));
+                    } else if(Objects.equals(studyId, study2.getStudyId()) && Objects.equals(participantId, study2Par2.getParticipantId())) {
+                        //Mock Timeline for Study 2 Participant 2
+                        // ... we expect one occurred Observation (observation 2)
+                        return createStudytimeline(List.of(
+                                createObservationTimelineEvent(
+                                        1,
+                                        //this event is one day in the future
+                                        lastOoTimestamp.plus(1, ChronoUnit.MINUTES).plus(1, ChronoUnit.DAYS),
+                                        lastOoTimestamp.plus(31, ChronoUnit.MINUTES).plus(1, ChronoUnit.DAYS)
+                                ),
+                                createObservationTimelineEvent(
+                                        2,
+                                        //this event was activated after the end of the previous run - should be ignored
+                                        testNowTimestamp.minus(1, ChronoUnit.MINUTES),
+                                        testNowTimestamp.plus(14, ChronoUnit.MINUTES)
+                                )));
+                    } else {
+                        return createStudytimeline(List.of()); //unexpected ... empty timeline
+                    }
+                });
+
+
+        //finally moch the two methods used in the occurredObservationService
+        when(occurredObservationService.getLatestStartTime(anyLong()))
+                .thenReturn(lastOoTimestamp);
+
+        when(occurredObservationService.upsert(anyLong(), anyInt(), anyInt(), any(), any()))
+                .thenAnswer(invocationOnMock ->
+                        new OccurredObservation(
+                                invocationOnMock.getArgument(0, Long.class),
+                                invocationOnMock.getArgument(1, Integer.class),
+                                invocationOnMock.getArgument(2, Integer.class),
+                                invocationOnMock.getArgument(3, Instant.class),
+                                invocationOnMock.getArgument(4, Instant.class)
+                        ));
+
+        upsertOccurredObservationsCron.upsertOccurredObservations();
+
+        //Assertions
+
+        //verify the the #getLatestStartTime(..) method is called for each study once
+        ArgumentCaptor<Long> studyIdCaptor = ArgumentCaptor.forClass(Long.class);
+        verify(occurredObservationService, times(2))
+                .getLatestStartTime(studyIdCaptor.capture());
+        assertThat(studyIdCaptor.getAllValues()).contains(1L, 2L);
+
+        ArgumentCaptor<Long> ooStudyIdCaptor = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<Integer> ooObservationIdCaptor = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Integer> ooParticipantIdCaptor = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Instant> ooStartCaptor = ArgumentCaptor.forClass(Instant.class);
+        ArgumentCaptor<Instant> ooEndCaptor = ArgumentCaptor.forClass(Instant.class);
+        //All in all we expect 5 OccurredObservations to be created
+        verify(occurredObservationService, times(5)).upsert(
+                ooStudyIdCaptor.capture(),
+                ooObservationIdCaptor.capture(),
+                ooParticipantIdCaptor.capture(),
+                ooStartCaptor.capture(),
+                ooEndCaptor.capture());
+        // Assert the expected values for the 5 expected OccurredObservations
+        //  Study 1, participant 1, observation 2
+        //  Study 1, participant 3, observation 1
+        //  Study 1, participant 3, observation 3
+        //  Study 2, participant 1, observation 1
+        //  Study 2, participant 2, observation 2
+        assertThat(ooStudyIdCaptor.getAllValues()).containsExactly(1L, 1L, 1L,  2L, 2L);
+        assertThat(ooObservationIdCaptor.getAllValues()).containsExactly(2, 1, 3, 1,  2);
+        assertThat(ooParticipantIdCaptor.getAllValues()).containsExactly(1, 3, 3, 1,  2);
+        assertThat(ooStartCaptor.getAllValues()).containsExactly(
+                lastOoTimestamp.plus(1, ChronoUnit.MINUTES),
+                testNowTimestamp.minus(1, ChronoUnit.MINUTES),
+                lastOoTimestamp.plus(1, ChronoUnit.MINUTES),
+                testNowTimestamp.minus(1, ChronoUnit.MINUTES),
+                testNowTimestamp.minus(1, ChronoUnit.MINUTES)
+        );
+        assertThat(ooEndCaptor.getAllValues()).containsExactly(
+                lastOoTimestamp.plus(31, ChronoUnit.MINUTES),
+                testNowTimestamp.plus(14, ChronoUnit.MINUTES),
+                lastOoTimestamp.plus(31, ChronoUnit.MINUTES),
+                testNowTimestamp.plus(14, ChronoUnit.MINUTES),
+                testNowTimestamp.plus(14, ChronoUnit.MINUTES)
+        );
+    }
+
+    private static StudyTimeline createStudytimeline(List<ObservationTimelineEvent> events) {
+        return new StudyTimeline(
+                Instant.now(), //bot used
+                Range.of(LocalDate.now().minusDays(14), LocalDate.now()), //not used
+                events,
+                List.of()
+        );
+    }
+
+    private static ObservationTimelineEvent createObservationTimelineEvent(int observationId, Instant start, Instant end) {
+        return new ObservationTimelineEvent(
+                observationId,
+                1, //not used
+                "TimelineEvent for Observation " + observationId,
+                "test purpose", //purpose is no used
+                "test", //type is not used
+                //this event is in the future - should be ignored
+                start,
+                end,
+                false, //not used
+                "scheduleType" //not used
+        );
+    }
+
+}


### PR DESCRIPTION
This adds functionality that create `OccurredObservation` based on study participants timelines. Basically a OccurredObservation is upsert in the repository within 5min after an observation started for a study participant:

* Corn runs all 5 minutes
* retrieves all active studies
* retrieves the timestamp of the latest `OccurredObservation` per study
* iterates over all participants of the study
* retrieves the Timeline for each participants
* creates `OccurredObservation` for all Observations that started after the latest and including the current time (minute resolution)

Changes:

* Introduces an `ACTIVE_STATES` EnumSet in the `Study.Status` enumeration. The two active states where hard coded in several locations in the code
* The StudyRepository & Service now allows to iterate over all Studies in a set of `Study.Status`.
    * returns a `Stream` to avoid loading all Studies into memory
    * expanded the component test for the StudyRepository to validate this functionality
* `UpsertOccurredObservationsCron`: Implements the business logic of creating `OccurredObservations` for study participants as described above

Possible Improvements:

* The period of 5 minutes is currently hard coded. Making this configureable is not much work.

Notes:

First tried to use the `SchedulingServie` and an `Job` Implementation to schedule a job for every active study, but gave up this idea as this infrastructure seamed complex. Especially storing the id returned by each submitted job seamed like a big burden, as it requires persistence, what is somehow provided by the SDK, but really hard to understand. Having different Cron Jobs for separate Studies running at an offset would be nice. But the advantage seamed not worth the effort.