### PR TITLE
#441 increase http timeout on articat uploads

### DIFF
--- a/.github/workflows/compile-test.yml
+++ b/.github/workflows/compile-test.yml
@@ -84,6 +84,7 @@ jobs:
             -Djib.to.tags=${TAGS}
             -Djib.to.auth.username=${{ github.actor }}
             -Djib.to.auth.password=${{ secrets.GITHUB_TOKEN }}
+            -Djib.httpTimeout=120000 #2min
         env:
           DOCKER_NAMESPACE: ghcr.io/${{ github.repository_owner }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} #Required for publishing to GitHub Packages

--- a/.github/workflows/compile-test.yml
+++ b/.github/workflows/compile-test.yml
@@ -84,7 +84,7 @@ jobs:
             -Djib.to.tags=${TAGS}
             -Djib.to.auth.username=${{ github.actor }}
             -Djib.to.auth.password=${{ secrets.GITHUB_TOKEN }}
-            -Djib.httpTimeout=120000 #2min
+            -Djib.httpTimeout=300000 #5min
         env:
           DOCKER_NAMESPACE: ghcr.io/${{ github.repository_owner }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} #Required for publishing to GitHub Packages


### PR DESCRIPTION
Try to increase http read timeout on artifact uploads to avoid an `[ERROR] {"errors":[{"code":"BLOB_UPLOAD_UNKNOWN","message":"blob upload unknown to registry"}]}` while uploading artefacts. See https://github.com/GoogleContainerTools/jib/issues/4301#issuecomment-2623224828 for information