### PR TITLE
#353: A first version for DataValidation tracking

### DIFF
--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/component/Component.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/component/Component.java
@@ -9,12 +9,13 @@
 package io.redlink.more.studymanager.core.component;
 
 import io.redlink.more.studymanager.core.exception.ConfigurationValidationException;
+import io.redlink.more.studymanager.core.factory.ComponentFactory;
 import io.redlink.more.studymanager.core.properties.ComponentProperties;
 
-public abstract class Component<C extends ComponentProperties> {
-    protected final C properties;
+public abstract class Component<P extends ComponentProperties> {
+    protected final P properties;
 
-    Component(C properties) throws ConfigurationValidationException {
+    Component(P properties) throws ConfigurationValidationException {
         this.properties = properties;
     }
 

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/component/Observation.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/component/Observation.java
@@ -75,7 +75,7 @@ public abstract class Observation<C extends ObservationProperties> extends Compo
             return new ObservationValidationResult(false, ObservationDataState.MISSING);
         }
         if(observationDataSummary.numDocs() < 0) { //no data
-            return new ObservationValidationResult( false, ObservationDataState.MISSING);
+            return new ObservationValidationResult(false, ObservationDataState.MISSING);
         }
         //the default implementation assumes an observation to be complete if any data are availale
         return new ObservationValidationResult(false, ObservationDataState.COMPLETE);

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/component/Observation.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/component/Observation.java
@@ -8,12 +8,18 @@
  */
 package io.redlink.more.studymanager.core.component;
 
+import io.redlink.more.studymanager.core.datavalidity.ObservationDataState;
+import io.redlink.more.studymanager.core.datavalidity.ObservationDataSummary;
+import io.redlink.more.studymanager.core.datavalidity.ObservationValidationResult;
 import io.redlink.more.studymanager.core.exception.ConfigurationValidationException;
+import io.redlink.more.studymanager.core.io.SimpleParticipant;
 import io.redlink.more.studymanager.core.io.TimeRange;
 import io.redlink.more.studymanager.core.properties.ObservationProperties;
 import io.redlink.more.studymanager.core.sdk.MoreObservationSDK;
 import io.redlink.more.studymanager.core.ui.DataView;
 import io.redlink.more.studymanager.core.ui.DataViewInfo;
+
+import java.time.Instant;
 
 public abstract class Observation<C extends ObservationProperties> extends Component<C> {
 
@@ -55,4 +61,25 @@ public abstract class Observation<C extends ObservationProperties> extends Compo
     public void deactivate() {
         // no action
     }
+
+    /**
+     * Default implementation that checks if data are available. If any are present the validation is set to
+     * complete otherwise the state is set to missing
+     * @param start the start of the current observation. Important for repeating observation schedules.
+     * @param end the end of the observation. Important for repeating observation schedules.
+     * @param observationDataSummary the summary over available observation data in the time series index for this observation and a specific participant
+     * @return the validation result
+     */
+    public ObservationValidationResult validateData(Instant start, Instant end , ObservationDataSummary observationDataSummary) {
+        if(observationDataSummary == null) { //null indicates some problem. This will cause the check to be repeated
+            return new ObservationValidationResult( false, ObservationDataState.MISSING);
+        }
+        if(observationDataSummary.numDocs() < 0) { //no data
+            return new ObservationValidationResult( false, ObservationDataState.MISSING);
+        }
+        //the default implementation assumes an observation to be complete if any data are availale
+        return new ObservationValidationResult(false, ObservationDataState.COMPLETE);
+    }
+
+
 }

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/component/Observation.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/component/Observation.java
@@ -70,7 +70,7 @@ public abstract class Observation<C extends ObservationProperties> extends Compo
      * @param observationDataSummary the summary over available observation data in the time series index for this observation and a specific participant
      * @return the validation result
      */
-    public ObservationValidationResult validateData(Instant start, Instant end , ObservationDataSummary observationDataSummary) {
+    public ObservationValidationResult validateData(Instant start, Instant end, ObservationDataSummary observationDataSummary) {
         if(observationDataSummary == null) { //null indicates some problem. This will cause the check to be repeated
             return new ObservationValidationResult(false, ObservationDataState.MISSING);
         }

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/component/Observation.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/component/Observation.java
@@ -72,7 +72,7 @@ public abstract class Observation<C extends ObservationProperties> extends Compo
      */
     public ObservationValidationResult validateData(Instant start, Instant end , ObservationDataSummary observationDataSummary) {
         if(observationDataSummary == null) { //null indicates some problem. This will cause the check to be repeated
-            return new ObservationValidationResult( false, ObservationDataState.MISSING);
+            return new ObservationValidationResult(false, ObservationDataState.MISSING);
         }
         if(observationDataSummary.numDocs() < 0) { //no data
             return new ObservationValidationResult( false, ObservationDataState.MISSING);

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/datavalidity/BooleanFieldValue.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/datavalidity/BooleanFieldValue.java
@@ -1,0 +1,7 @@
+package io.redlink.more.studymanager.core.datavalidity;
+
+public record BooleanFieldValue(
+        Boolean value,
+        long count
+) {
+}

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/datavalidity/BooleanMeasurementSummary.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/datavalidity/BooleanMeasurementSummary.java
@@ -1,0 +1,8 @@
+package io.redlink.more.studymanager.core.datavalidity;
+
+import java.util.List;
+
+public record BooleanMeasurementSummary(
+        List<BooleanFieldValue> values
+) {
+}

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/datavalidity/DateMeasurementSummary.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/datavalidity/DateMeasurementSummary.java
@@ -1,0 +1,10 @@
+package io.redlink.more.studymanager.core.datavalidity;
+
+import java.time.Instant;
+
+public record DateMeasurementSummary(
+        Instant min,
+        Instant max,
+        long missing
+) {
+}

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/datavalidity/MeasurementSummary.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/datavalidity/MeasurementSummary.java
@@ -1,0 +1,76 @@
+package io.redlink.more.studymanager.core.datavalidity;
+
+import io.redlink.more.studymanager.core.measurement.Measurement;
+
+public class MeasurementSummary {
+    private final Measurement measurement;
+    private NumericMeasurementSummary numericResult;
+    private StringMeasurementSummary stringResult;
+    private BooleanMeasurementSummary booleanResult;
+    private DateMeasurementSummary dateResult;
+
+    public MeasurementSummary(Measurement measurement) {
+        this.measurement = measurement;
+    }
+
+    public void setNumericResult(NumericMeasurementSummary numericResult) {
+        this.numericResult = numericResult;
+    }
+
+    public void setStringResult(StringMeasurementSummary stringResult) {
+        this.stringResult = stringResult;
+    }
+
+    public void setBooleanResult(BooleanMeasurementSummary booleanResult) {
+        this.booleanResult = booleanResult;
+    }
+
+    public void setDateResult(DateMeasurementSummary dateResult) {
+        this.dateResult = dateResult;
+    }
+
+    /**
+     * Getter for the Measurement
+     * @return
+     */
+    public Measurement getMeasurement() {
+        return measurement;
+    }
+
+    /**
+     * Getter for information about numeric values. Only present
+     * of {@link Measurement#getType()} is {@link Measurement.Type#DOUBLE} or {@link Measurement.Type#INTEGER}
+     * @return
+     */
+    public NumericMeasurementSummary getNumericResult() {
+        return numericResult;
+    }
+
+    /**
+     * Getter for information about string values. Only present
+     * of {@link Measurement#getType()} is {@link Measurement.Type#STRING}}
+     * @return
+     */
+    public StringMeasurementSummary getStringResult() {
+        return stringResult;
+    }
+
+    /**
+     * Getter for information about boolean values. Only present
+     * of {@link Measurement#getType()} is {@link Measurement.Type#BOOLEAN}}
+     * @return
+     */
+    public BooleanMeasurementSummary getBooleanResult() {
+        return booleanResult;
+    }
+
+    /**
+     * Getter for information about date values. Only present
+     * of {@link Measurement#getType()} is {@link Measurement.Type#DATE}}
+     * @return
+     */
+    public DateMeasurementSummary getDateResult() {
+        return dateResult;
+    }
+
+}

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/datavalidity/NumericMeasurementSummary.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/datavalidity/NumericMeasurementSummary.java
@@ -1,0 +1,10 @@
+package io.redlink.more.studymanager.core.datavalidity;
+
+public record NumericMeasurementSummary(
+        double min,
+        double max,
+        double avg,
+        double sum,
+        long missing
+) {
+}

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/datavalidity/ObservationDataState.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/datavalidity/ObservationDataState.java
@@ -1,0 +1,32 @@
+package io.redlink.more.studymanager.core.datavalidity;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum ObservationDataState {
+    MISSING("missing"),
+    INCOMPLETE("incomplete"),
+    PARTIAL("partial"),
+    COMPLETE("complete");
+    private final String value;
+
+    ObservationDataState(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    private static final Map<String, ObservationDataState> LOOKUP;
+
+    static {
+        LOOKUP = Arrays.stream(ObservationDataState.values()).collect(Collectors.toMap(ObservationDataState::getValue, Function.identity()));
+    }
+
+    public static ObservationDataState fromValue(String value) {
+        return LOOKUP.get(value);
+    }
+}

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/datavalidity/ObservationDataSummary.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/datavalidity/ObservationDataSummary.java
@@ -1,0 +1,9 @@
+package io.redlink.more.studymanager.core.datavalidity;
+
+import java.util.List;
+
+public record ObservationDataSummary(
+    long numDocs,
+    DateMeasurementSummary effectiveTime,
+    List<MeasurementSummary> measurements
+) {}

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/datavalidity/ObservationValidationResult.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/datavalidity/ObservationValidationResult.java
@@ -1,0 +1,7 @@
+package io.redlink.more.studymanager.core.datavalidity;
+
+public record ObservationValidationResult(
+        boolean invalid,
+        ObservationDataState state
+) {
+}

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/datavalidity/StringFieldValue.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/datavalidity/StringFieldValue.java
@@ -1,0 +1,7 @@
+package io.redlink.more.studymanager.core.datavalidity;
+
+public record StringFieldValue(
+        String value,
+        long count
+) {
+}

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/datavalidity/StringMeasurementSummary.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/datavalidity/StringMeasurementSummary.java
@@ -1,0 +1,8 @@
+package io.redlink.more.studymanager.core.datavalidity;
+
+import java.util.List;
+
+public record StringMeasurementSummary(
+        List<StringFieldValue> values
+) {
+}

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/io/TimeRange.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/io/TimeRange.java
@@ -9,6 +9,6 @@
 package io.redlink.more.studymanager.core.io;
 
 public interface TimeRange {
-    public String getFromString();
-    public String getToString();
+    String getFromString();
+    String getToString();
 }

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/io/Timeframe.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/io/Timeframe.java
@@ -20,6 +20,14 @@ public class Timeframe implements TimeRange {
         this.to = to;
     }
 
+    public final Instant getFrom() {
+        return from;
+    }
+
+    public final Instant getTo() {
+        return to;
+    }
+
     @Override
     public String getFromString() {
         return from != null ? from.toString() : null;

--- a/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/PolarVerityObservation.java
+++ b/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/PolarVerityObservation.java
@@ -8,6 +8,7 @@
  */
 package io.redlink.more.studymanager.component.observation;
 
+import io.redlink.more.studymanager.component.observation.measurement.GenericMeasurementSets;
 import io.redlink.more.studymanager.core.component.Observation;
 import io.redlink.more.studymanager.core.exception.ConfigurationValidationException;
 import io.redlink.more.studymanager.core.io.TimeRange;

--- a/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/QuestionObservation.java
+++ b/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/QuestionObservation.java
@@ -190,7 +190,7 @@ public class QuestionObservation<C extends ObservationProperties> extends Observ
             return new ObservationValidationResult( false, ObservationDataState.MISSING);
         } else if(observationDataSummary.numDocs() > 1) {
             //only a single answer is allowed
-            return new ObservationValidationResult( true, ObservationDataState.COMPLETE);
+            return new ObservationValidationResult(true, ObservationDataState.COMPLETE);
         } else {
             MeasurementSummary answerMeasurementSummary = observationDataSummary.measurements().stream()
                     .filter(it -> QuestionObservationFactory.FIELD_ANSWER.equals(it.getMeasurement().getId()))
@@ -198,7 +198,7 @@ public class QuestionObservation<C extends ObservationProperties> extends Observ
                     .orElse(null);
             boolean hasAnswers = answerMeasurementSummary != null &&
                     answerMeasurementSummary.getStringResult().values().stream().noneMatch(it -> it.value() != null);
-            return new ObservationValidationResult( !hasAnswers, ObservationDataState.COMPLETE);
+            return new ObservationValidationResult(!hasAnswers, ObservationDataState.COMPLETE);
         }
     }
 }

--- a/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/QuestionObservation.java
+++ b/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/QuestionObservation.java
@@ -9,12 +9,17 @@
 package io.redlink.more.studymanager.component.observation;
 
 import io.redlink.more.studymanager.core.component.Observation;
+import io.redlink.more.studymanager.core.datavalidity.MeasurementSummary;
+import io.redlink.more.studymanager.core.datavalidity.ObservationDataState;
+import io.redlink.more.studymanager.core.datavalidity.ObservationDataSummary;
+import io.redlink.more.studymanager.core.datavalidity.ObservationValidationResult;
 import io.redlink.more.studymanager.core.exception.ConfigurationValidationException;
 import io.redlink.more.studymanager.core.io.TimeRange;
 import io.redlink.more.studymanager.core.properties.ObservationProperties;
 import io.redlink.more.studymanager.core.sdk.MoreObservationSDK;
 import io.redlink.more.studymanager.core.ui.*;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -34,7 +39,7 @@ public class QuestionObservation<C extends ObservationProperties> extends Observ
                         List.of(),
                         null,
                         ViewConfig.Aggregation.TERM_FIELD,
-                        new ViewConfig.Operation(ViewConfig.Operator.COUNT, "answer")
+                        new ViewConfig.Operation(ViewConfig.Operator.COUNT, QuestionObservationFactory.FIELD_ANSWER)
                 )
         ),
         answers_by_group("responseDistributionStudyGroup",
@@ -43,7 +48,7 @@ public class QuestionObservation<C extends ObservationProperties> extends Observ
                         List.of(),
                         ViewConfig.Aggregation.TERM_FIELD,
                         ViewConfig.Aggregation.STUDY_GROUP,
-                        new ViewConfig.Operation(ViewConfig.Operator.COUNT, "answer")
+                        new ViewConfig.Operation(ViewConfig.Operator.COUNT, QuestionObservationFactory.FIELD_ANSWER)
                 )
         ),
         group_by_answers("responseDistributionResponse",
@@ -52,7 +57,7 @@ public class QuestionObservation<C extends ObservationProperties> extends Observ
                         List.of(),
                         ViewConfig.Aggregation.STUDY_GROUP,
                         ViewConfig.Aggregation.TERM_FIELD,
-                        new ViewConfig.Operation(ViewConfig.Operator.COUNT, "answer")
+                        new ViewConfig.Operation(ViewConfig.Operator.COUNT, QuestionObservationFactory.FIELD_ANSWER)
                 )
         ),
         ;
@@ -174,5 +179,26 @@ public class QuestionObservation<C extends ObservationProperties> extends Observ
         }
 
         return new DataViewData(labels, rows);
+    }
+
+    @Override
+    public ObservationValidationResult validateData(Instant start, Instant end, ObservationDataSummary observationDataSummary) {
+        if(observationDataSummary == null) { //null indicates some problem. This will cause the check to be repeated
+            return new ObservationValidationResult( false, ObservationDataState.MISSING);
+        }
+        if(observationDataSummary.numDocs() < 0) { //no data
+            return new ObservationValidationResult( false, ObservationDataState.MISSING);
+        } else if(observationDataSummary.numDocs() > 1) {
+            //only a single answer is allowed
+            return new ObservationValidationResult( true, ObservationDataState.COMPLETE);
+        } else {
+            MeasurementSummary answerMeasurementSummary = observationDataSummary.measurements().stream()
+                    .filter(it -> QuestionObservationFactory.FIELD_ANSWER.equals(it.getMeasurement().getId()))
+                    .findFirst()
+                    .orElse(null);
+            boolean hasAnswers = answerMeasurementSummary != null &&
+                    answerMeasurementSummary.getStringResult().values().stream().noneMatch(it -> it.value() != null);
+            return new ObservationValidationResult( !hasAnswers, ObservationDataState.COMPLETE);
+        }
     }
 }

--- a/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/QuestionObservation.java
+++ b/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/QuestionObservation.java
@@ -184,7 +184,7 @@ public class QuestionObservation<C extends ObservationProperties> extends Observ
     @Override
     public ObservationValidationResult validateData(Instant start, Instant end, ObservationDataSummary observationDataSummary) {
         if(observationDataSummary == null) { //null indicates some problem. This will cause the check to be repeated
-            return new ObservationValidationResult( false, ObservationDataState.MISSING);
+            return new ObservationValidationResult(false, ObservationDataState.MISSING);
         }
         if(observationDataSummary.numDocs() < 0) { //no data
             return new ObservationValidationResult( false, ObservationDataState.MISSING);

--- a/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/QuestionObservation.java
+++ b/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/QuestionObservation.java
@@ -187,7 +187,7 @@ public class QuestionObservation<C extends ObservationProperties> extends Observ
             return new ObservationValidationResult(false, ObservationDataState.MISSING);
         }
         if(observationDataSummary.numDocs() < 0) { //no data
-            return new ObservationValidationResult( false, ObservationDataState.MISSING);
+            return new ObservationValidationResult(false, ObservationDataState.MISSING);
         } else if(observationDataSummary.numDocs() > 1) {
             //only a single answer is allowed
             return new ObservationValidationResult(true, ObservationDataState.COMPLETE);

--- a/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/QuestionObservationFactory.java
+++ b/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/QuestionObservationFactory.java
@@ -25,8 +25,10 @@ import java.util.Set;
 public class QuestionObservationFactory<C extends Observation<P>, P extends ObservationProperties>
         extends ObservationFactory<C, P> {
 
+    public static final String FIELD_ANSWER =  "answer";
+
     private static final MeasurementSet measurements = new MeasurementSet(
-            "SIMPLE_ANSWER", Set.of(new Measurement("answer", Measurement.Type.STRING))
+            "SIMPLE_ANSWER", Set.of(new Measurement(FIELD_ANSWER, Measurement.Type.STRING))
     );
 
     private static List<Value> properties = List.of(

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/model/OccurredObservation.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/model/OccurredObservation.java
@@ -1,12 +1,9 @@
 package io.redlink.more.studymanager.model;
 
+import io.redlink.more.studymanager.core.datavalidity.ObservationDataState;
 import io.redlink.more.studymanager.core.properties.OccurredObservationProperties;
 
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * An observation of a participant in the context of a study.
@@ -22,7 +19,7 @@ public record OccurredObservation(
         Instant start,
         Instant end,
         Boolean dataValid,
-        DataState dataState,
+        ObservationDataState dataState,
         OccurredObservationProperties properties,
         Instant created,
         Instant modified
@@ -34,7 +31,7 @@ public record OccurredObservation(
             Instant start,
             Instant end,
             Boolean dataValid,
-            DataState dataState,
+            ObservationDataState dataState,
             OccurredObservationProperties properties
     ) {
         this(studyId, observationId, participantId, start, end, dataValid, dataState, properties, null, null);
@@ -46,31 +43,7 @@ public record OccurredObservation(
             Instant start,
             Instant end
     ) {
-        this(studyId, observationId, participantId, start, end, true, DataState.MISSING, new OccurredObservationProperties());
+        this(studyId, observationId, participantId, start, end, true, ObservationDataState.MISSING, new OccurredObservationProperties());
     }
 
-    public enum DataState {
-        MISSING("missing"),
-        INCOMPLETE("incomplete"),
-        PARTIAL("partial"),
-        COMPLETE("complete");
-        private final String value;
-
-        DataState(String value) {
-            this.value = value;
-        }
-
-        public String getValue() {
-            return value;
-        }
-
-        private static final Map<String, DataState> LOOKUP;
-        static {
-            LOOKUP = Arrays.stream(DataState.values()).collect(Collectors.toMap(DataState::getValue, Function.identity()));
-        }
-
-        public static DataState fromValue(String value) {
-            return LOOKUP.get(value);
-        }
-    }
 }

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/repository/OccurredObservationRepository.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/repository/OccurredObservationRepository.java
@@ -10,6 +10,7 @@ package io.redlink.more.studymanager.repository;
 
 import io.redlink.more.studymanager.core.properties.OccurredObservationProperties;
 import io.redlink.more.studymanager.exception.BadRequestException;
+import io.redlink.more.studymanager.core.datavalidity.ObservationDataState;
 import io.redlink.more.studymanager.model.OccurredObservation;
 import io.redlink.more.studymanager.utils.MapperUtils;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -123,20 +124,20 @@ public class OccurredObservationRepository {
     public Stream<OccurredObservation> listOccurredObservations(
             Long studyId, Integer participantId, Integer observationId,
             Boolean dataValid,
-            Set<OccurredObservation.DataState> dataStates
+            Set<ObservationDataState> dataStates
     ) {
         return namedTemplate.queryForStream(LIST_OCCURRED_OBSERVATION,
                 new MapSqlParameterSource("study_id", studyId)
                         .addValue("participant_id", participantId)
                         .addValue("observation_id", observationId)
                         .addValue("data_valid", dataValid)
-                        .addValue("data_states", dataStates == null ? null : dataStates.stream().map(OccurredObservation.DataState::getValue).toArray(String[]::new)),
+                        .addValue("data_states", dataStates == null ? null : dataStates.stream().map(ObservationDataState::getValue).toArray(String[]::new)),
                 getOccurredObservationRowMapper());
     }
 
     public Instant getLatestStartTime(
             Long studyId, Integer participantId, Integer observationId,
-            Boolean dataValid, Set<OccurredObservation.DataState> dataStates
+            Boolean dataValid, Set<ObservationDataState> dataStates
     ) {
         try {
             return namedTemplate.queryForObject(FIND_LAST_START_TIME,
@@ -144,7 +145,7 @@ public class OccurredObservationRepository {
                             .addValue("participant_id", participantId)
                             .addValue("observation_id", observationId)
                             .addValue("data_valid", dataValid)
-                            .addValue("data_states", dataStates == null ? null : dataStates.stream().map(OccurredObservation.DataState::getValue).toArray(String[]::new)),
+                            .addValue("data_states", dataStates == null ? null : dataStates.stream().map(ObservationDataState::getValue).toArray(String[]::new)),
                     getInstantRowMapper("start", true));
         } catch (EmptyResultDataAccessException e) {
             return null;
@@ -192,7 +193,7 @@ public class OccurredObservationRepository {
                 RepositoryUtils.readInstantUTC(rs, "start"),
                 RepositoryUtils.readInstantUTC(rs, "end"),
                 rs.getBoolean("data_valid"),
-                OccurredObservation.DataState.fromValue(rs.getString("data_state")),
+                ObservationDataState.fromValue(rs.getString("data_state")),
                 MapperUtils.readValue(rs.getString("properties"), OccurredObservationProperties.class),
                 RepositoryUtils.readInstant(rs, "created"),
                 RepositoryUtils.readInstant(rs, "modified")

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/scheduling/ValidateActiveObservationDataCron.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/scheduling/ValidateActiveObservationDataCron.java
@@ -1,0 +1,169 @@
+package io.redlink.more.studymanager.scheduling;
+
+import io.redlink.more.studymanager.core.datavalidity.ObservationDataState;
+import io.redlink.more.studymanager.core.factory.ObservationFactory;
+import io.redlink.more.studymanager.core.io.TimeRange;
+import io.redlink.more.studymanager.core.io.Timeframe;
+import io.redlink.more.studymanager.model.*;
+import io.redlink.more.studymanager.sdk.MoreSDK;
+import io.redlink.more.studymanager.service.ObservationService;
+import io.redlink.more.studymanager.service.OccurredObservationService;
+import io.redlink.more.studymanager.service.ParticipantService;
+import io.redlink.more.studymanager.service.StudyService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class ValidateActiveObservationDataCron {
+
+    private static final Logger log = LoggerFactory.getLogger(ValidateActiveObservationDataCron.class);
+    private final StudyService studyService;
+    private final ParticipantService participantService;
+    private final OccurredObservationService occurredObservationService;
+    private final ObservationService observationService;
+    private final MoreSDK sdk;
+
+
+    public ValidateActiveObservationDataCron(
+            StudyService studyService,
+            ParticipantService participantService,
+            OccurredObservationService occurredObservationService,
+            ObservationService observationService,
+            MoreSDK sdk
+    ){
+        this.studyService = studyService;
+        this.participantService = participantService;
+        this.occurredObservationService = occurredObservationService;
+        this.observationService = observationService;
+        this.sdk = sdk;
+    }
+
+
+
+    @Scheduled(cron="30 */5 * * * ?") //every 5min, 30sec after updating active observation data
+    public void validateActiveObservationData(){
+        Map<String, ObservationFactory>  observationFactories = new HashMap<>();
+        studyService.getStudiesByStates(Study.Status.ACTIVE_STATES).forEach(study -> {
+            //NOTE: OccurredObservations will refer the same observations and participants several times, A single lookup
+            //      per run is sufficient, so we keep them in a cache
+            Map<Integer, Observation> observationCache = new HashMap<>();
+            Map<Integer, Participant> participantCache = new HashMap<>();
+            Map<Integer, io.redlink.more.studymanager.core.component.Observation> observationComponentCache = new HashMap<>();
+            try (var ooStrem = occurredObservationService.streamActiveOccurredObservations(study.getStudyId(), false)) {
+                ooStrem.forEach(occuredObservation ->
+                    validateOccurrence(
+                            study,
+                            occuredObservation,
+                            observationCache,
+                            observationFactories,
+                            observationComponentCache,
+                            participantCache));
+            }
+        });
+    }
+
+    private void validateOccurrence(Study study, OccurredObservation occuredObservation, Map<Integer, Observation> observationCache, Map<String, ObservationFactory> observationFactories, Map<Integer, io.redlink.more.studymanager.core.component.Observation> observationComponentCache, Map<Integer, Participant> participantCache) {
+        var observation = observationCache.computeIfAbsent(
+                occuredObservation.observationId(),
+                key -> observationService.getObservation(study.getStudyId(), key).orElse(null));
+        var observationFactory = observationFactories.computeIfAbsent(
+                observation.getType(),
+                key -> observationService.getObservationFactory(observation).orElse(null));
+        io.redlink.more.studymanager.core.component.Observation observationComponent;
+        if (observationFactory != null) {
+            observationComponent = observationComponentCache.computeIfAbsent(
+                    observation.getObservationId(),
+                    key -> observationFactory.create(
+                            sdk.scopedObservationSDK(study.getStudyId(), observation.getStudyGroupId(), key),
+                            observation.getProperties()));
+        } else {
+            observationComponent = null;
+        }
+        validate(new ValidateionContext(
+                study,
+                occuredObservation,
+                participantCache.computeIfAbsent(
+                        occuredObservation.participantId(),
+                        key -> participantService.getParticipant(study.getStudyId(), key)),
+                observation,
+                observationFactory,
+                observationComponent));
+    }
+
+
+    private void validate(ValidateionContext ctx) {
+        if(Instant.now().isBefore(ctx.occurrence.start())) {
+            //do not try to validate occurrences that are in the future
+            log.warn("Unexpected call to validate {} with a future start timestamp", ctx.occurrence);
+            return;
+        }
+        var validationResults = sdk.validateData(
+            ctx.getStudyId(), ctx.getStudyGroupId(),ctx.getObservationId(),
+            ctx.participant.getParticipantId(), ctx.getTimeRage(),
+            ctx.observationFactory.getMeasurementSet());
+        final OccurredObservation updatedOccurredObservation;
+        if(validationResults != null) {
+            var validationResult = ctx.observationComponent.validateData(ctx.occurrence.start(), ctx.occurrence.end(), validationResults);
+            updatedOccurredObservation = new OccurredObservation(
+                    ctx.occurrence.studyId(),
+                    ctx.occurrence.observationId(),
+                    ctx.occurrence.participantId(),
+                    ctx.occurrence.start(),
+                    ctx.occurrence.end(),
+                    !validationResult.invalid(),
+                    validationResult.state(),
+                    ctx.occurrence.properties()
+            );
+        } else { //validation failed
+            updatedOccurredObservation = new OccurredObservation(
+                    ctx.occurrence.studyId(),
+                    ctx.occurrence.observationId(),
+                    ctx.occurrence.participantId(),
+                    ctx.occurrence.start(),
+                    ctx.occurrence.end(),
+                    ctx.occurrence.dataValid(),
+                    ObservationDataState.MISSING,
+                    ctx.occurrence.properties()
+            );
+        }
+        occurredObservationService.update(updatedOccurredObservation);
+    }
+
+
+    private record ValidateionContext(
+        Study study,
+        OccurredObservation occurrence,
+        Participant participant,
+        Observation observation,
+        ObservationFactory observationFactory,
+        io.redlink.more.studymanager.core.component.Observation observationComponent
+    ) {
+
+        public Long getStudyId(){
+            return study.getStudyId();
+        }
+
+        public Integer getStudyGroupId(){
+            return observation.getStudyGroupId();
+        }
+
+        public Integer getObservationId(){
+            return observation.getObservationId();
+        }
+
+        public Integer getParticipantId(){
+            return participant.getParticipantId();
+        }
+
+        public TimeRange getTimeRage() {
+            return new Timeframe(occurrence.start(), occurrence.end());
+        }
+    }
+
+}

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/sdk/MoreSDK.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/sdk/MoreSDK.java
@@ -8,8 +8,10 @@
  */
 package io.redlink.more.studymanager.sdk;
 
+import io.redlink.more.studymanager.core.datavalidity.ObservationDataSummary;
 import io.redlink.more.studymanager.core.io.SimpleParticipant;
 import io.redlink.more.studymanager.core.io.TimeRange;
+import io.redlink.more.studymanager.core.measurement.MeasurementSet;
 import io.redlink.more.studymanager.core.properties.ObservationProperties;
 import io.redlink.more.studymanager.core.sdk.MoreActionSDK;
 import io.redlink.more.studymanager.core.sdk.MoreObservationSDK;
@@ -188,4 +190,14 @@ public class MoreSDK {
             return null;
         }
     }
+    public ObservationDataSummary validateData(long studyId, Integer studyGroupId, int observationId, int participantId, TimeRange timerange, MeasurementSet measurementSet) {
+        try {
+            return elasticDataService.validateObservationData(studyId, studyGroupId, observationId, participantId, timerange, measurementSet);
+        } catch (IOException e) {
+            LOGGER.warn("Failed to query observation data to validate data for observation: {} of study: {} and participant: {} in time range {} and meassurements: {}",
+                    observationId, studyId, participantId, timerange, measurementSet, e);
+            return null;
+        }
+    }
+
 }

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/sdk/scoped/MoreObservationSDKImpl.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/sdk/scoped/MoreObservationSDKImpl.java
@@ -88,5 +88,4 @@ public class MoreObservationSDKImpl extends MorePlatformSDKImpl implements MoreO
         return sdk.queryData(viewConfig, studyId, studyGroupId, observationId, participantId, timerange);
     }
 
-
 }

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/sdk/scoped/MoreObservationSDKImpl.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/sdk/scoped/MoreObservationSDKImpl.java
@@ -87,5 +87,4 @@ public class MoreObservationSDKImpl extends MorePlatformSDKImpl implements MoreO
     public DataViewData queryData(ViewConfig viewConfig, Integer studyGroupId, Integer participantId, TimeRange timerange) {
         return sdk.queryData(viewConfig, studyId, studyGroupId, observationId, participantId, timerange);
     }
-
 }

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/sdk/scoped/MoreObservationSDKImpl.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/sdk/scoped/MoreObservationSDKImpl.java
@@ -87,4 +87,6 @@ public class MoreObservationSDKImpl extends MorePlatformSDKImpl implements MoreO
     public DataViewData queryData(ViewConfig viewConfig, Integer studyGroupId, Integer participantId, TimeRange timerange) {
         return sdk.queryData(viewConfig, studyId, studyGroupId, observationId, participantId, timerange);
     }
+
+
 }

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ElasticDataService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ElasticDataService.java
@@ -10,27 +10,22 @@ package io.redlink.more.studymanager.service;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
-import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
-import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
-import co.elastic.clients.elasticsearch._types.aggregations.DateHistogramBucket;
-import co.elastic.clients.elasticsearch._types.aggregations.MinimumInterval;
-import co.elastic.clients.elasticsearch._types.aggregations.MultiBucketBase;
-import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
+import co.elastic.clients.elasticsearch._types.aggregations.*;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.util.ObjectBuilder;
+import io.redlink.more.studymanager.core.datavalidity.*;
 import io.redlink.more.studymanager.core.io.TimeRange;
+import io.redlink.more.studymanager.core.measurement.Measurement;
+import io.redlink.more.studymanager.core.measurement.MeasurementSet;
 import io.redlink.more.studymanager.core.ui.DataViewData;
 import io.redlink.more.studymanager.core.ui.DataViewRow;
 import io.redlink.more.studymanager.core.ui.ViewConfig;
 import io.redlink.more.studymanager.model.StudyGroup;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.time.Instant;
+import java.util.*;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -62,7 +57,10 @@ public class ElasticDataService {
         this.studyGroupService = studyGroupService;
     }
 
-    public DataViewData queryObservationViewData(ViewConfig viewConfig, long studyId, Integer studyGroupId, int observationId, Integer participantId, TimeRange timerange) throws IOException {
+    public DataViewData queryObservationViewData(
+            ViewConfig viewConfig, long studyId, Integer studyGroupId, int observationId, Integer participantId,
+            TimeRange timerange
+    ) throws IOException {
         final List<Query> filters = getFilters(studyId, observationId, studyGroupId, participantId, timerange);
 
         final SearchRequest.Builder builder = buildDataPreviewRequest(viewConfig, filters, studyId);
@@ -76,6 +74,172 @@ public class ElasticDataService {
         }
     }
 
+    public ObservationDataSummary validateObservationData(
+            long studyId, Integer studyGroupId, int observationId, int participantId,
+            TimeRange timerange, MeasurementSet measurementSet
+    ) throws IOException {
+        final List<Query> filters = getFilters(studyId, observationId, studyGroupId, participantId, timerange);
+        final SearchRequest.Builder requestBuilder = new SearchRequest.Builder()
+                .index(getStudyIdString(studyId))
+                .query(q -> q.bool(b -> b.filter(filters)))
+                .size(0);
+        if(measurementSet != null) {
+            buildMeasurementSetAggregations(requestBuilder, measurementSet);
+        } //else no data fields to validate ... just check if any documents are present
+        final SearchRequest request = requestBuilder.build();
+
+        try {
+            final SearchResponse<Void> searchResponse = client.search(request, Void.class);
+            return parseValidationResults(measurementSet, searchResponse, studyId);
+        } catch (IOException | ElasticsearchException e) {
+            return ElasticService.handleIndexNotFoundException(e, () -> null, IOException::new);
+        }
+    }
+
+    private SearchRequest.Builder buildMeasurementSetAggregations(SearchRequest.Builder builder, MeasurementSet measurementSet) {
+        for (Measurement measurement : measurementSet.values()) {
+            String id = measurement.getId();
+            if (id == null) {
+                continue;
+            }
+            String field = "data_" + id;
+            Measurement.Type type = measurement.getType();
+            switch (type) {
+                case STRING:
+                    String termsName = field + "_counts";
+                    builder.aggregations(termsName, Aggregation.of(a -> a.terms(t -> t.field(field + ".keyword").missing("missing"))));
+                    break;
+                case BOOLEAN:
+                    String boolTermsName = field + "_counts";
+                    builder.aggregations(boolTermsName, Aggregation.of(a -> a.terms(t -> t.field(field).missing("missing"))));
+                    break;
+                case INTEGER:
+                case DOUBLE:
+                case DATE:
+                    String statsName = field + "_stats";
+                    builder.aggregations(statsName, Aggregation.of(a -> a.stats(s -> s.field(field))));
+                    String missingName = field + "_missing";
+                    builder.aggregations(missingName, Aggregation.of(a -> a.missing(m -> m.field(field))));
+                    break;
+                case OBJECT:
+                    // do nothing
+                    break;
+            }
+        }
+        // Add aggregations for effective_time_frame
+        builder.aggregations("min_effective_time_frame", Aggregation.of(a -> a.min(m -> m.field("effective_time_frame"))));
+        builder.aggregations("max_effective_time_frame", Aggregation.of(a -> a.max(m -> m.field("effective_time_frame"))));
+        builder.aggregations("effective_time_frame_missing", Aggregation.of(a -> a.missing(m -> m.field("effective_time_frame"))));
+        // Add aggregation for numDocs
+        builder.aggregations("total_docs", Aggregation.of(a -> a.valueCount(v -> v.field("study_id.keyword"))));
+        return builder;
+    }
+    private ObservationDataSummary parseValidationResults(MeasurementSet measurementSet, SearchResponse<Void> searchResponse, long studyId) {
+        long numDocs;
+        DateMeasurementSummary effectiveTime = null;
+        List<MeasurementSummary> measurements = Collections.emptyList();
+
+        if (searchResponse.aggregations().isEmpty()) {
+            // measurementSet was null
+            numDocs = searchResponse.hits().total().value();
+        } else {
+            ValueCountAggregate totalAgg = searchResponse.aggregations().get("total_docs").valueCount();
+            numDocs = (long)totalAgg.value();
+
+            // Parse effective_time_frame
+            MinAggregate minEffAgg = searchResponse.aggregations().get("min_effective_time_frame").min();
+            double minVal = minEffAgg.value();
+            Instant minInst = (minVal == Double.POSITIVE_INFINITY) ? null : Instant.ofEpochMilli((long) minVal);
+
+            MaxAggregate maxEffAgg = searchResponse.aggregations().get("max_effective_time_frame").max();
+            double maxVal = maxEffAgg.value();
+            Instant maxInst = (maxVal == Double.NEGATIVE_INFINITY) ? null : Instant.ofEpochMilli((long) maxVal);
+
+            MissingAggregate missEffAgg = searchResponse.aggregations().get("effective_time_frame_missing").missing();
+            long effMissing = missEffAgg.docCount();
+
+            effectiveTime = new DateMeasurementSummary(minInst, maxInst, effMissing);
+
+            // Parse measurements
+            measurements = new ArrayList<>();
+            for (Measurement measurement : measurementSet.values()) {
+                String id = measurement.getId();
+                if (id == null) {
+                    continue;
+                }
+                String field = "data_" + id;
+                Measurement.Type type = measurement.getType();
+                MeasurementSummary mv = new MeasurementSummary(measurement);
+
+                switch (type) {
+                    case STRING:
+                        String termsName = field + "_counts";
+                        StringTermsAggregate stringTerms = searchResponse.aggregations().get(termsName).sterms();
+                        List<StringFieldValue> stringValues = new ArrayList<>();
+                        for (StringTermsBucket bucket : stringTerms.buckets().array()) {
+                            String key = bucket.key().stringValue();
+                            long count = bucket.docCount();
+                            String value = "missing".equals(key) ? null : key;
+                            stringValues.add(new StringFieldValue(value, count));
+                        }
+                        mv.setStringResult(new StringMeasurementSummary(stringValues));
+                        break;
+                    case BOOLEAN:
+                        String boolTermsName = field + "_counts";
+                        StringTermsAggregate boolTerms = searchResponse.aggregations().get(boolTermsName).sterms();
+                        List<BooleanFieldValue> boolValues = new ArrayList<>();
+                        for (StringTermsBucket bucket : boolTerms.buckets().array()) {
+                            String key = bucket.key().stringValue();
+                            long count = bucket.docCount();
+                            Boolean value;
+                            if ("missing".equals(key)) {
+                                value = null;
+                            } else if ("true".equals(key)) {
+                                value = Boolean.TRUE;
+                            } else if ("false".equals(key)) {
+                                value = Boolean.FALSE;
+                            } else {
+                                continue; // unexpected
+                            }
+                            boolValues.add(new BooleanFieldValue(value, count));
+                        }
+                        mv.setBooleanResult(new BooleanMeasurementSummary(boolValues));
+                        break;
+                    case INTEGER:
+                    case DOUBLE:
+                        String numericStatsName = field + "_stats";
+                        StatsAggregate numericStats = searchResponse.aggregations().get(numericStatsName).stats();
+                        String numericMissingName = field + "_missing";
+                        MissingAggregate numericMiss = searchResponse.aggregations().get(numericMissingName).missing();
+                        double min = (numericStats.min() == Double.POSITIVE_INFINITY) ? Double.NaN : numericStats.min();
+                        double max = (numericStats.max() == Double.NEGATIVE_INFINITY) ? Double.NaN : numericStats.max();
+                        double avg = numericStats.avg();
+                        double sum = numericStats.sum();
+                        long missing = numericMiss.docCount();
+                        mv.setNumericResult(new NumericMeasurementSummary(min, max, avg, sum, missing));
+                        break;
+                    case DATE:
+                        String dateStatsName = field + "_stats";
+                        StatsAggregate dateStats = searchResponse.aggregations().get(dateStatsName).stats();
+                        String dateMissingName = field + "_missing";
+                        MissingAggregate dateMiss = searchResponse.aggregations().get(dateMissingName).missing();
+                        double dateMinVal = dateStats.min();
+                        Instant dateMinInst = (dateMinVal == Double.POSITIVE_INFINITY) ? null : Instant.ofEpochMilli((long) dateMinVal);
+                        double dateMaxVal = dateStats.max();
+                        Instant dateMaxInst = (dateMaxVal == Double.NEGATIVE_INFINITY) ? null : Instant.ofEpochMilli((long) dateMaxVal);
+                        long dateMissing = dateMiss.docCount();
+                        mv.setDateResult(new DateMeasurementSummary(dateMinInst, dateMaxInst, dateMissing));
+                        break;
+                    case OBJECT:
+                        // do nothing
+                        break;
+                }
+                measurements.add(mv);
+            }
+        }
+
+        return new ObservationDataSummary(numDocs, effectiveTime, measurements);
+    }
     private SearchRequest.Builder buildDataPreviewRequest(ViewConfig viewConfig, List<Query> filters, long studyId) {
         final var rows = viewConfig.rowAggregation();
         final var series = viewConfig.seriesAggregation();

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ElasticDataService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ElasticDataService.java
@@ -23,12 +23,14 @@ import io.redlink.more.studymanager.core.ui.DataViewData;
 import io.redlink.more.studymanager.core.ui.DataViewRow;
 import io.redlink.more.studymanager.core.ui.ViewConfig;
 import io.redlink.more.studymanager.model.StudyGroup;
+
 import java.io.IOException;
 import java.time.Instant;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -83,7 +85,7 @@ public class ElasticDataService {
                 .index(getStudyIdString(studyId))
                 .query(q -> q.bool(b -> b.filter(filters)))
                 .size(0);
-        if(measurementSet != null) {
+        if (measurementSet != null) {
             buildMeasurementSetAggregations(requestBuilder, measurementSet);
         } //else no data fields to validate ... just check if any documents are present
         final SearchRequest request = requestBuilder.build();
@@ -134,6 +136,7 @@ public class ElasticDataService {
         builder.aggregations("total_docs", Aggregation.of(a -> a.valueCount(v -> v.field("study_id.keyword"))));
         return builder;
     }
+
     private ObservationDataSummary parseValidationResults(MeasurementSet measurementSet, SearchResponse<Void> searchResponse, long studyId) {
         long numDocs;
         DateMeasurementSummary effectiveTime = null;
@@ -144,7 +147,7 @@ public class ElasticDataService {
             numDocs = searchResponse.hits().total().value();
         } else {
             ValueCountAggregate totalAgg = searchResponse.aggregations().get("total_docs").valueCount();
-            numDocs = (long)totalAgg.value();
+            numDocs = (long) totalAgg.value();
 
             // Parse effective_time_frame
             MinAggregate minEffAgg = searchResponse.aggregations().get("min_effective_time_frame").min();
@@ -169,7 +172,7 @@ public class ElasticDataService {
                 }
                 String field = "data_" + id;
                 Measurement.Type type = measurement.getType();
-                MeasurementSummary mv = new MeasurementSummary(measurement);
+                MeasurementSummary ms = new MeasurementSummary(measurement);
 
                 switch (type) {
                     case STRING:
@@ -182,7 +185,7 @@ public class ElasticDataService {
                             String value = "missing".equals(key) ? null : key;
                             stringValues.add(new StringFieldValue(value, count));
                         }
-                        mv.setStringResult(new StringMeasurementSummary(stringValues));
+                        ms.setStringResult(new StringMeasurementSummary(stringValues));
                         break;
                     case BOOLEAN:
                         String boolTermsName = field + "_counts";
@@ -203,7 +206,7 @@ public class ElasticDataService {
                             }
                             boolValues.add(new BooleanFieldValue(value, count));
                         }
-                        mv.setBooleanResult(new BooleanMeasurementSummary(boolValues));
+                        ms.setBooleanResult(new BooleanMeasurementSummary(boolValues));
                         break;
                     case INTEGER:
                     case DOUBLE:
@@ -216,7 +219,7 @@ public class ElasticDataService {
                         double avg = numericStats.avg();
                         double sum = numericStats.sum();
                         long missing = numericMiss.docCount();
-                        mv.setNumericResult(new NumericMeasurementSummary(min, max, avg, sum, missing));
+                        ms.setNumericResult(new NumericMeasurementSummary(min, max, avg, sum, missing));
                         break;
                     case DATE:
                         String dateStatsName = field + "_stats";
@@ -228,18 +231,19 @@ public class ElasticDataService {
                         double dateMaxVal = dateStats.max();
                         Instant dateMaxInst = (dateMaxVal == Double.NEGATIVE_INFINITY) ? null : Instant.ofEpochMilli((long) dateMaxVal);
                         long dateMissing = dateMiss.docCount();
-                        mv.setDateResult(new DateMeasurementSummary(dateMinInst, dateMaxInst, dateMissing));
+                        ms.setDateResult(new DateMeasurementSummary(dateMinInst, dateMaxInst, dateMissing));
                         break;
                     case OBJECT:
                         // do nothing
                         break;
                 }
-                measurements.add(mv);
+                measurements.add(ms);
             }
         }
 
         return new ObservationDataSummary(numDocs, effectiveTime, measurements);
     }
+
     private SearchRequest.Builder buildDataPreviewRequest(ViewConfig viewConfig, List<Query> filters, long studyId) {
         final var rows = viewConfig.rowAggregation();
         final var series = viewConfig.seriesAggregation();
@@ -288,23 +292,22 @@ public class ElasticDataService {
             return Function.identity();
         }
 
-        final Map<String, String> mapping =  switch (aggregation) {
-            case PARTICIPANT ->
-                participantService.listParticipants(studyId)
-                        .stream()
-                        .collect(Collectors.toMap(
-                                p -> ElasticService.getParticipantIdString(p.getParticipantId()),
-                                p -> String.format("%s (%d)", p.getAlias(), p.getParticipantId())
-                        ));
+        final Map<String, String> mapping = switch (aggregation) {
+            case PARTICIPANT -> participantService.listParticipants(studyId)
+                    .stream()
+                    .collect(Collectors.toMap(
+                            p -> ElasticService.getParticipantIdString(p.getParticipantId()),
+                            p -> String.format("%s (%d)", p.getAlias(), p.getParticipantId())
+                    ));
 
             case STUDY_GROUP -> {
                 final Map<String, String> m = new HashMap<>(
                         studyGroupService.listStudyGroups(studyId)
-                        .stream()
-                        .collect(Collectors.toMap(
-                                g -> ElasticService.getStudyGroupIdString(g.getStudyGroupId()),
-                                StudyGroup::getTitle
-                        ))
+                                .stream()
+                                .collect(Collectors.toMap(
+                                        g -> ElasticService.getStudyGroupIdString(g.getStudyGroupId()),
+                                        StudyGroup::getTitle
+                                ))
                 );
                 m.put(NO_GROUP_KEY, "i18n.global.placeholder.noGroup");
                 yield m;

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ObservationService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ObservationService.java
@@ -144,6 +144,10 @@ public class ObservationService {
         ).getView(viewName, studyGroupId, participantId, timerange);
     }
 
+    public Optional<ObservationFactory> getObservationFactory(Observation observation) {
+        return Optional.ofNullable(factory(observation));
+    }
+
     private ObservationFactory factory(Observation observation) {
         return observationFactories.get(observation.getType());
     }

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/OccurredObservationService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/OccurredObservationService.java
@@ -8,6 +8,7 @@
  */
 package io.redlink.more.studymanager.service;
 
+import io.redlink.more.studymanager.core.datavalidity.ObservationDataState;
 import io.redlink.more.studymanager.model.OccurredObservation;
 import io.redlink.more.studymanager.repository.OccurredObservationRepository;
 import org.springframework.stereotype.Service;
@@ -21,8 +22,8 @@ public class OccurredObservationService {
 
     private final OccurredObservationRepository repository;
 
-    private static final EnumSet<OccurredObservation.DataState> COMPLETED_DATA_STATES = EnumSet.of(OccurredObservation.DataState.COMPLETE);
-    private static final EnumSet<OccurredObservation.DataState> ACTIVE_DATA_STATES = EnumSet.complementOf(COMPLETED_DATA_STATES);
+    private static final EnumSet<ObservationDataState> COMPLETED_DATA_STATES = EnumSet.of(ObservationDataState.COMPLETE);
+    private static final EnumSet<ObservationDataState> ACTIVE_DATA_STATES = EnumSet.complementOf(COMPLETED_DATA_STATES);
 
     public OccurredObservationService(OccurredObservationRepository repository) {
         this.repository = repository;
@@ -47,7 +48,7 @@ public class OccurredObservationService {
 
     /**
      * Stream over all occurred observations for a study, where data is still missing (not in
-     * {@link io.redlink.more.studymanager.model.OccurredObservation.DataState#COMPLETE})
+     * {@link ObservationDataState#COMPLETE})
      * @param studyId the study id
      * @param includeInvalid if occurred observations marked as having invalid data are included
      * @return a stream over all ongoing or occurred observations where data are still missing
@@ -61,7 +62,7 @@ public class OccurredObservationService {
 
     /**
      * Stream over all occurred observations for a observation of a study, where data is still missing (not in
-     * {@link io.redlink.more.studymanager.model.OccurredObservation.DataState#COMPLETE})
+     * {@link ObservationDataState#COMPLETE})
      * @param studyId the study id
      * @param observationId the observation id
      * @param includeInvalid if occurred observations marked as having invalid data are included
@@ -76,7 +77,7 @@ public class OccurredObservationService {
 
     /**
      * Stream over all occurred observations for a participant of a study, where data is still missing (not in
-     * {@link io.redlink.more.studymanager.model.OccurredObservation.DataState#COMPLETE})
+     * {@link ObservationDataState#COMPLETE})
      * @param studyId the study id
      * @param participantId the participant id
      * @param includeInvalid if occurred observations marked as having invalid data are included
@@ -87,6 +88,22 @@ public class OccurredObservationService {
                 studyId, participantId, null,
                 includeInvalid ? null : true,
                 ACTIVE_DATA_STATES);
+    }
+    /**
+     * Stream over all occurred observations for a participant of a study, where data is still missing (not in
+     * {@link ObservationDataState#COMPLETE})
+     * @param studyId the study id
+     * @param participantId the participant id or <code>null</code> as wildcard
+     * @param observationId the observation id  or <code>null</code> as wildcard
+     * @param includeInvalid if occurred observations marked as having invalid data are included
+     * @param observationDataStates the states to include or <code>null</code> to include all
+     * @return a stream over all ongoing or occurred observations where data are still missing
+     */
+    public Stream<OccurredObservation> streamOccurredObservations(long studyId, Integer participantId, Integer observationId, boolean includeInvalid, Set<ObservationDataState> observationDataStates) {
+        return repository.listOccurredObservations(
+                studyId, participantId, observationId,
+                includeInvalid ? null : true,
+                observationDataStates == null ? EnumSet.allOf(ObservationDataState.class) : observationDataStates);
     }
 
 }

--- a/studymanager-services/src/test/java/io/redlink/more/studymanager/repository/OccurredObservationRepositoryTest.java
+++ b/studymanager-services/src/test/java/io/redlink/more/studymanager/repository/OccurredObservationRepositoryTest.java
@@ -9,6 +9,7 @@
 package io.redlink.more.studymanager.repository;
 
 import io.redlink.more.studymanager.configuration.JPAConfiguration;
+import io.redlink.more.studymanager.core.datavalidity.ObservationDataState;
 import io.redlink.more.studymanager.core.properties.ObservationProperties;
 import io.redlink.more.studymanager.core.properties.OccurredObservationProperties;
 import io.redlink.more.studymanager.model.*;
@@ -23,8 +24,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.Instant;
@@ -109,7 +108,7 @@ class OccurredObservationRepositoryTest {
         assertThat(occurredObservationResponse.start()).isEqualTo(startTime);
         assertThat(occurredObservationResponse.end()).isEqualTo(endTime);
         assertThat(occurredObservationResponse.dataValid()).isTrue();
-        assertThat(occurredObservationResponse.dataState()).isEqualTo(OccurredObservation.DataState.MISSING);
+        assertThat(occurredObservationResponse.dataState()).isEqualTo(ObservationDataState.MISSING);
         assertThat(occurredObservationResponse.properties()).isNotNull();
         assertThat(occurredObservationResponse.properties()).isEmpty();
         assertThat(occurredObservationResponse.created()).isNotNull();
@@ -126,7 +125,7 @@ class OccurredObservationRepositoryTest {
                 occurredObservationResponse.start(),
                 occurredObservationResponse.end(),
                 false, //change data valid
-                OccurredObservation.DataState.INCOMPLETE,
+                ObservationDataState.INCOMPLETE,
                 new OccurredObservationProperties(Map.of("test", "dummy", "testInt", 69))
         );
 
@@ -139,7 +138,7 @@ class OccurredObservationRepositoryTest {
         assertThat(updatedOccurentObservationResponse.start()).isEqualTo(startTime);
         assertThat(updatedOccurentObservationResponse.end()).isEqualTo(endTime);
         assertThat(updatedOccurentObservationResponse.dataValid()).isFalse(); //UPDATED
-        assertThat(updatedOccurentObservationResponse.dataState()).isEqualTo(OccurredObservation.DataState.INCOMPLETE);
+        assertThat(updatedOccurentObservationResponse.dataState()).isEqualTo(ObservationDataState.INCOMPLETE);
         assertThat(updatedOccurentObservationResponse.properties()).isNotNull();
         assertThat(updatedOccurentObservationResponse.properties()).hasSize(2);
         assertThat(updatedOccurentObservationResponse.properties().getString("test")).isEqualTo("dummy");
@@ -157,7 +156,7 @@ class OccurredObservationRepositoryTest {
                 updatedOccurentObservationResponse.start(),
                 updatedOccurentObservationResponse.end().plus(1, ChronoUnit.HOURS),
                 true, //change data valid
-                OccurredObservation.DataState.COMPLETE,
+                ObservationDataState.COMPLETE,
                 new OccurredObservationProperties(Map.of("test", "dummy-changed", "testInt", 42))
         ));
 
@@ -169,7 +168,7 @@ class OccurredObservationRepositoryTest {
         assertThat(duplicateInsertResponse.end()).isEqualTo(endTime.plus(1, ChronoUnit.HOURS)); //UPDATED
         //NOT UPDATED FIELDS!!
         assertThat(duplicateInsertResponse.dataValid()).isFalse(); //NOT TRUE
-        assertThat(duplicateInsertResponse.dataState()).isEqualTo(OccurredObservation.DataState.INCOMPLETE); //NOT COMPLETE
+        assertThat(duplicateInsertResponse.dataState()).isEqualTo(ObservationDataState.INCOMPLETE); //NOT COMPLETE
         assertThat(duplicateInsertResponse.properties()).isNotNull();
         assertThat(duplicateInsertResponse.properties()).hasSize(2);
         assertThat(duplicateInsertResponse.properties().getString("test")).isEqualTo("dummy"); //NOT dummy-changed
@@ -206,25 +205,25 @@ class OccurredObservationRepositoryTest {
         //Oservation 1, Participant 1, Yesterday
         var ooO1P1Y = occurredObservationRepository.upsert(new OccurredObservation(
                 studyId, observation.getObservationId(), participant.getParticipantId(), startTime.minus(1, ChronoUnit.DAYS), endTime.minus(1, ChronoUnit.DAYS),
-                true, OccurredObservation.DataState.COMPLETE, new OccurredObservationProperties()));
+                true, ObservationDataState.COMPLETE, new OccurredObservationProperties()));
         var ooO1P2T = occurredObservationRepository.upsert(new OccurredObservation(
                 studyId, observation.getObservationId(), participant2.getParticipantId(), startTime, endTime,
-                true, OccurredObservation.DataState.MISSING, new OccurredObservationProperties()));
+                true, ObservationDataState.MISSING, new OccurredObservationProperties()));
         var ooO1P2Y = occurredObservationRepository.upsert(new OccurredObservation(
                 studyId, observation.getObservationId(), participant2.getParticipantId(), startTime.minus(1, ChronoUnit.DAYS), endTime.minus(1, ChronoUnit.DAYS),
-                true, OccurredObservation.DataState.MISSING, new OccurredObservationProperties()));
+                true, ObservationDataState.MISSING, new OccurredObservationProperties()));
         var ooO2P1T = occurredObservationRepository.upsert(new OccurredObservation(
                 studyId, observation2.getObservationId(), participant.getParticipantId(), startTime2, endTime2,
-                true, OccurredObservation.DataState.INCOMPLETE, new OccurredObservationProperties()));
+                true, ObservationDataState.INCOMPLETE, new OccurredObservationProperties()));
         var ooO2P1Y = occurredObservationRepository.upsert(new OccurredObservation(
                 studyId, observation2.getObservationId(), participant.getParticipantId(), startTime2.minus(1, ChronoUnit.DAYS), endTime2.minus(1, ChronoUnit.DAYS),
-                true, OccurredObservation.DataState.COMPLETE, new OccurredObservationProperties()));
+                true, ObservationDataState.COMPLETE, new OccurredObservationProperties()));
         var ooO2P2T = occurredObservationRepository.upsert(new OccurredObservation(
                 studyId, observation2.getObservationId(), participant2.getParticipantId(), startTime2, endTime2,
-                true, OccurredObservation.DataState.PARTIAL, new OccurredObservationProperties()));
+                true, ObservationDataState.PARTIAL, new OccurredObservationProperties()));
         var ooO2P2Y = occurredObservationRepository.upsert(new OccurredObservation(
                 studyId, observation2.getObservationId(), participant2.getParticipantId(), startTime2.minus(1, ChronoUnit.DAYS), endTime2.minus(1, ChronoUnit.DAYS),
-                false, OccurredObservation.DataState.COMPLETE, new OccurredObservationProperties()));
+                false, ObservationDataState.COMPLETE, new OccurredObservationProperties()));
 
         //List OccurredObservations for Participant 1
         var p1oos = occurredObservationRepository.listOccurredObservations(studyId, participant.getParticipantId(), null, null, null).toList();
@@ -237,7 +236,7 @@ class OccurredObservationRepositoryTest {
         assertThat(o1p2oos).hasSize(2);
         assertThat(o1p2oos).containsExactlyInAnyOrder(ooO1P2T, ooO1P2Y);
         //List OccurredObservations in the State Incomplete or partial
-        var sIPoos = occurredObservationRepository.listOccurredObservations(studyId, null, null, null, EnumSet.of(OccurredObservation.DataState.INCOMPLETE, OccurredObservation.DataState.PARTIAL)).toList();
+        var sIPoos = occurredObservationRepository.listOccurredObservations(studyId, null, null, null, EnumSet.of(ObservationDataState.INCOMPLETE, ObservationDataState.PARTIAL)).toList();
         assertThat(sIPoos).isNotNull();
         assertThat(sIPoos).hasSize(3);
         assertThat(sIPoos).containsExactlyInAnyOrder(ooO1P1T, ooO2P1T, ooO2P2T);
@@ -251,7 +250,7 @@ class OccurredObservationRepositoryTest {
         var lastStartTimeStudy = occurredObservationRepository.getLatestStartTime(studyId, null, null, null, null);
         assertThat(lastStartTimeStudy).isNotNull();
         assertThat(lastStartTimeStudy).isEqualTo(startTime);
-        var lastStartTimeStateP2StateComplete =  occurredObservationRepository.getLatestStartTime(studyId, participant2.getParticipantId(), null, null, EnumSet.of(OccurredObservation.DataState.COMPLETE));
+        var lastStartTimeStateP2StateComplete =  occurredObservationRepository.getLatestStartTime(studyId, participant2.getParticipantId(), null, null, EnumSet.of(ObservationDataState.COMPLETE));
         assertThat(lastStartTimeStateP2StateComplete).isNotNull();
         assertThat(lastStartTimeStateP2StateComplete).isEqualTo(startTime2.minus(1, ChronoUnit.DAYS));
         //validate that searching for a combination with no entry returns null

--- a/studymanager-services/src/test/java/io/redlink/more/studymanager/service/ElasticDataServiceTest.java
+++ b/studymanager-services/src/test/java/io/redlink/more/studymanager/service/ElasticDataServiceTest.java
@@ -126,7 +126,6 @@ class ElasticDataServiceTest {
 
     }
 
-
     public static SearchResponse<Void> deserializeJsonToSearchResponse(InputStream json) throws IOException {
         var jsonFactory = new JsonFactory();
         var jacksonParser = jsonFactory.createParser(json);

--- a/studymanager-services/src/test/java/io/redlink/more/studymanager/service/ElasticDataServiceTest.java
+++ b/studymanager-services/src/test/java/io/redlink/more/studymanager/service/ElasticDataServiceTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Elastic License 2.0.
+ */
+package io.redlink.more.studymanager.service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.json.JsonpDeserializer;
+import co.elastic.clients.json.JsonpMapper;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.json.jackson.JacksonJsonpParser;
+import com.fasterxml.jackson.core.JsonFactory;
+import io.redlink.more.studymanager.core.datavalidity.MeasurementSummary;
+import io.redlink.more.studymanager.core.datavalidity.StringFieldValue;
+import io.redlink.more.studymanager.core.io.Timeframe;
+import io.redlink.more.studymanager.core.measurement.Measurement;
+import io.redlink.more.studymanager.core.measurement.MeasurementSet;
+import jakarta.json.stream.JsonParser;
+import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@ExtendWith(MockitoExtension.class)
+class ElasticDataServiceTest {
+
+    private final static Logger LOG = LoggerFactory.getLogger(ElasticDataServiceTest.class);
+
+    private ElasticDataService elasticDataService;
+
+    private ElasticsearchClient client = Mockito.mock(ElasticsearchClient.class);
+
+    private ParticipantService participantServic = Mockito.mock(ParticipantService.class);
+
+    private StudyGroupService studyGroupService =  Mockito.mock(StudyGroupService.class);
+
+    @BeforeEach
+    void init() {
+        elasticDataService = new ElasticDataService(client, participantServic, studyGroupService);
+    }
+
+    @Test
+    public void testValidateObservationData() throws IOException {
+
+        MeasurementSet measurementSet = new MeasurementSet("test", Set.of(
+            new Measurement("activityType", Measurement.Type.STRING),
+            new Measurement("activeTimeInSeconds", Measurement.Type.INTEGER),
+            new Measurement("maxMotionIntensity", Measurement.Type.DOUBLE),
+            new Measurement("active", Measurement.Type.BOOLEAN)
+        ));
+        SearchResponse<Void> expectedResponse;
+        try(InputStream responseData = ElasticDataServiceTest.class.getClassLoader().getResourceAsStream("testdata/validateObservationDataResponse1.json")){
+            expectedResponse = deserializeJsonToSearchResponse(responseData);
+        }
+        ArgumentCaptor<Long> requestCaptor = ArgumentCaptor.forClass(Long.class);
+        when(client.search(any(SearchRequest.class), any(Class.class))).thenReturn(expectedResponse);
+
+        var results = elasticDataService.validateObservationData(15,null,1, 11,
+                new Timeframe(
+                        Instant.parse("2025-12-01T16:00:00Z"),
+                        Instant.parse("2025-12-02T00:00:00Z")),
+                measurementSet);
+
+        assertThat(results).isNotNull();
+        assertThat(results.numDocs()).isEqualTo(49);
+        assertThat(results.measurements().stream().map(MeasurementSummary::getMeasurement).collect(Collectors.toSet())).isEqualTo(measurementSet.values());
+        assertThat(results.effectiveTime().min()).isEqualTo(Instant.parse("2025-12-01T16:00:00.000Z"));
+        assertThat(results.effectiveTime().max()).isEqualTo(Instant.parse("2025-12-02T00:00:00.000Z"));
+
+        MeasurementSummary activityTypeValue = results.measurements().stream().filter(mv -> mv.getMeasurement().getId().equals("activityType")).findFirst().orElse(null);
+        assertThat(activityTypeValue).isNotNull();
+        assertThat(activityTypeValue.getStringResult()).isNotNull();
+        assertThat(activityTypeValue.getStringResult().values().stream().map(StringFieldValue::value).collect(Collectors.toList())).containsExactlyInAnyOrder("SEDENTARY", "WALKING", "GENERIC");
+        assertThat(activityTypeValue.getStringResult().values().stream().filter(it -> "SEDENTARY".equals(it.value())).findFirst().get().count()).isEqualTo(40);
+        assertThat(activityTypeValue.getStringResult().values().stream().filter(it -> "WALKING".equals(it.value())).findFirst().get().count()).isEqualTo(8);
+        assertThat(activityTypeValue.getStringResult().values().stream().filter(it -> "GENERIC".equals(it.value())).findFirst().get().count()).isEqualTo(1);
+
+
+        MeasurementSummary activeTimeInSecondsValue = results.measurements().stream().filter(mv -> mv.getMeasurement().getId().equals("activeTimeInSeconds")).findFirst().orElse(null);
+        assertThat(activeTimeInSecondsValue).isNotNull();
+        assertThat(activeTimeInSecondsValue.getNumericResult()).isNotNull();
+        assertThat(activeTimeInSecondsValue.getNumericResult().missing()).isEqualTo(0);
+        assertThat(activeTimeInSecondsValue.getNumericResult().min()).isEqualTo(0.0);
+        assertThat(activeTimeInSecondsValue.getNumericResult().max()).isEqualTo(900.0);
+        assertThat(activeTimeInSecondsValue.getNumericResult().avg()).isEqualTo(657.244, Offset.offset(0.01));
+        assertThat(activeTimeInSecondsValue.getNumericResult().sum()).isEqualTo(32205.0);
+
+        MeasurementSummary maxMotionIntensityValue = results.measurements().stream().filter(mv -> mv.getMeasurement().getId().equals("maxMotionIntensity")).findFirst().orElse(null);
+        assertThat(maxMotionIntensityValue).isNotNull();
+        assertThat(maxMotionIntensityValue.getNumericResult()).isNotNull();
+        assertThat(maxMotionIntensityValue.getNumericResult().missing()).isEqualTo(0);
+        assertThat(maxMotionIntensityValue.getNumericResult().min()).isEqualTo(0.0);
+        assertThat(maxMotionIntensityValue.getNumericResult().max()).isEqualTo(6.0);
+        assertThat(maxMotionIntensityValue.getNumericResult().avg()).isEqualTo(3.0816, Offset.offset(0.01));
+        assertThat(maxMotionIntensityValue.getNumericResult().sum()).isEqualTo(151.0);
+
+        MeasurementSummary activeStateValue = results.measurements().stream().filter(mv -> mv.getMeasurement().getId().equals("active")).findFirst().orElse(null);
+        assertThat(activeStateValue).isNotNull();
+        assertThat(activeStateValue.getBooleanResult()).isNotNull();
+        assertThat(activeStateValue.getBooleanResult().values().size()).isEqualTo(1);
+        //we only have missing values as the data do not provide any boolean Measurement
+        assertThat(activeStateValue.getBooleanResult().values().stream().filter(it -> it.value() == null).findFirst().get().count()).isEqualTo(49);
+
+    }
+
+
+    public static SearchResponse<Void> deserializeJsonToSearchResponse(InputStream json) throws IOException {
+        var jsonFactory = new JsonFactory();
+        var jacksonParser = jsonFactory.createParser(json);
+        var mapper = new JacksonJsonpMapper();
+        JsonParser parser  = new JacksonJsonpParser(jacksonParser, mapper);
+
+        var documentDeserializer = new JsonpDeserializer<Void>() {
+            public Void deserialize(JsonParser parser , JsonpMapper mapper) {
+                parser.skipArray();
+                parser.skipObject();
+                return null;
+            }
+            public Void deserialize(JsonParser parser , JsonpMapper mapper , JsonParser.Event event) {
+            if (event == JsonParser.Event.VALUE_NULL) {
+                return null;
+            }
+            parser.skipArray();
+            parser.skipObject();
+            return null;
+            }
+
+            public EnumSet<JsonParser.Event> acceptedEvents() {
+                return EnumSet.of(JsonParser.Event.START_OBJECT, JsonParser.Event.VALUE_NULL);
+            }
+
+            public EnumSet<JsonParser.Event> nativeEvents() {
+                return EnumSet.noneOf(JsonParser.Event.class);
+            }
+        };
+
+        var responseDeserializer = SearchResponse.createSearchResponseDeserializer(documentDeserializer);
+        return responseDeserializer.deserialize(parser, mapper);
+    }
+
+}

--- a/studymanager-services/src/test/resources/testdata/validateObservationDataResponse1.json
+++ b/studymanager-services/src/test/resources/testdata/validateObservationDataResponse1.json
@@ -1,0 +1,82 @@
+{
+  "took": 8,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 49,
+      "relation": "eq"
+    },
+    "max_score": null,
+    "hits": []
+  },
+  "aggregations": {
+    "sterms#data_activityType_counts": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "SEDENTARY",
+          "doc_count": 40
+        },
+        {
+          "key": "WALKING",
+          "doc_count": 8
+        },
+        {
+          "key": "GENERIC",
+          "doc_count": 1
+        }
+      ]
+    },
+    "missing#effective_time_frame_missing": {
+      "doc_count": 0
+    },
+    "max#max_effective_time_frame": {
+      "value": 1.7646336E12,
+      "value_as_string": "2025-12-02T00:00:00.000Z"
+    },
+    "missing#data_activeTimeInSeconds_missing": {
+      "doc_count": 0
+    },
+    "sterms#data_active_counts": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "missing",
+          "doc_count": 49
+        }
+      ]
+    },
+    "value_count#total_docs": {
+      "value": 49
+    },
+    "missing#data_maxMotionIntensity_missing": {
+      "doc_count": 0
+    },
+    "stats#data_activeTimeInSeconds_stats": {
+      "count": 49,
+      "min": 0.0,
+      "max": 900.0,
+      "avg": 657.2448979591836,
+      "sum": 32205.0
+    },
+    "stats#data_maxMotionIntensity_stats": {
+      "count": 49,
+      "min": 0.0,
+      "max": 6.0,
+      "avg": 3.0816326530612246,
+      "sum": 151.0
+    },
+    "min#min_effective_time_frame": {
+      "value": 1.7646048E12,
+      "value_as_string": "2025-12-01T16:00:00.000Z"
+    }
+  }
+}

--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/OccurredObservationsApiV1Controller.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/OccurredObservationsApiV1Controller.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Elastic License 2.0.
+ */
+package io.redlink.more.studymanager.controller.studymanager;
+
+import io.redlink.more.studymanager.api.v1.model.OccurredObservationDTO;
+import io.redlink.more.studymanager.api.v1.webservices.OccuredObserrvationsApi;
+import io.redlink.more.studymanager.exception.BadRequestException;
+import io.redlink.more.studymanager.model.*;
+import io.redlink.more.studymanager.model.transformer.OccurredObservationTransformer;
+import io.redlink.more.studymanager.properties.GatewayProperties;
+import io.redlink.more.studymanager.service.ObservationService;
+import io.redlink.more.studymanager.service.OccurredObservationService;
+import io.redlink.more.studymanager.service.ParticipantService;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping(value = "/api/v1", produces = MediaType.APPLICATION_JSON_VALUE)
+public class OccurredObservationsApiV1Controller implements OccuredObserrvationsApi {
+
+    private final OccurredObservationService ooService;
+    private final ParticipantService participantService;
+    private final ObservationService observationService;
+    private final GatewayProperties gatewayProperties;
+
+    public OccurredObservationsApiV1Controller(
+            OccurredObservationService ooService,
+            ParticipantService participantService,
+            ObservationService observationService,
+            GatewayProperties gatewayProperties
+    ) {
+        this.ooService = ooService;
+        this.participantService = participantService;
+        this.observationService = observationService;
+        this.gatewayProperties = gatewayProperties;
+    }
+
+    @Override
+    public ResponseEntity<List<OccurredObservationDTO>> listOccurredObservations(Long studyId, Integer participant, Integer observation, Instant from, Instant to) {
+        if(studyId == null) {
+            throw new BadRequestException("studyId is required");
+        }
+        if(participant == null && observation == null) {
+            throw new BadRequestException("either participant or observation is required");
+        }
+        List<OccurredObservation> occurredObservations;
+        try(var ooStream = ooService.streamOccurredObservations(studyId, participant, observation, true, null)) {
+            occurredObservations = ooStream.filter(it -> (from == null || it.start().equals(from) || it.start().isAfter(from)) &&
+                    (to == null || it.end().equals(to) || it.end().isBefore(to)))
+                    //sort for start DESC and end ASC ... this means that the most current OccirredObservations are listed first
+                    .sorted(Comparator.comparing(OccurredObservation::start).reversed().thenComparing(OccurredObservation::end))
+                    .toList();
+        }
+
+        //retrieve all participants and observations referenced by OccurredObservations
+        var referencedParticipants = occurredObservations.stream()
+                .map(OccurredObservation::participantId)
+                .collect(Collectors.toSet()).stream()
+                .map(participantId -> participantService.getParticipant(studyId,participantId))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toMap(p -> p.getParticipantId(), Function.identity()));
+        var referencedObservations = occurredObservations.stream()
+                .map(OccurredObservation::observationId)
+                .collect(Collectors.toSet()).stream()
+                .map(participantId -> observationService.getObservation(studyId,participantId))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toMap(o -> o.getObservationId(), Function.identity()));
+
+        //Convert the data and send the response
+        return ResponseEntity.ok(occurredObservations.stream().map( it ->
+                new OccurredObservationData(
+                        it,
+                        referencedParticipants.get(it.participantId()),
+                        referencedObservations.get(it.observationId())
+                ))
+                .map(it -> OccurredObservationTransformer.toOccurredObservationDTO_V1(it, gatewayProperties))
+                .toList());
+    }
+
+    /**
+     * Record that holds data requried to serialize {@link OccurredObservation} as defined in the API
+     * @param occurredObservation
+     * @param participant
+     * @param observation
+     */
+    public record OccurredObservationData(
+            OccurredObservation occurredObservation,
+            Participant participant,
+            Observation observation
+    ){ }
+}

--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ParticipantsApiV1Controller.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ParticipantsApiV1Controller.java
@@ -12,11 +12,14 @@ import io.redlink.more.studymanager.api.v1.model.ParticipantDTO;
 import io.redlink.more.studymanager.api.v1.webservices.ParticipantsApi;
 import io.redlink.more.studymanager.audit.Audited;
 import io.redlink.more.studymanager.controller.RequiresStudyRole;
+import io.redlink.more.studymanager.core.datavalidity.ObservationDataState;
 import io.redlink.more.studymanager.exception.NotFoundException;
+import io.redlink.more.studymanager.model.OccurredObservation;
 import io.redlink.more.studymanager.model.Participant;
 import io.redlink.more.studymanager.model.StudyRole;
 import io.redlink.more.studymanager.model.transformer.ParticipantTransformer;
 import io.redlink.more.studymanager.properties.GatewayProperties;
+import io.redlink.more.studymanager.service.OccurredObservationService;
 import io.redlink.more.studymanager.service.ParticipantService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -24,23 +27,38 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.Instant;
 import java.util.List;
+import java.util.stream.Stream;
 
 @RestController
 @RequestMapping(value = "/api/v1", produces = MediaType.APPLICATION_JSON_VALUE)
 public class ParticipantsApiV1Controller implements ParticipantsApi {
     private final ParticipantService service;
+    private final OccurredObservationService occurredObservationService;
     private final GatewayProperties gatewayProperties;
 
 
-    public ParticipantsApiV1Controller(ParticipantService service, GatewayProperties gatewayProperties) {
+    public ParticipantsApiV1Controller(ParticipantService service, OccurredObservationService occurredObservationService, GatewayProperties gatewayProperties) {
         this.service = service;
+        this.occurredObservationService = occurredObservationService;
         this.gatewayProperties = gatewayProperties;
     }
 
     private ParticipantDTO toParticipantDTO(Participant p) {
         return ParticipantTransformer.toParticipantDTO_V1(p, gatewayProperties);
     }
+    private ParticipantDTO.DataHealthIndicatorEnum getDataHealthIndicator(long studyId, int participantId) {
+        var now = Instant.now();
+        try (Stream<OccurredObservation> ooStream = occurredObservationService.streamActiveOccurredObservationsForParticipant(studyId, participantId, true)){
+            if(ooStream.anyMatch(it -> it.dataValid() == Boolean.FALSE ||
+                    (now.isAfter(it.end()) && it.dataState() != ObservationDataState.COMPLETE))){
+                return ParticipantDTO.DataHealthIndicatorEnum.ORANGE;
+            } else {
+                return ParticipantDTO.DataHealthIndicatorEnum.GREEN;
+            }
+        }
+   }
 
     @Override
     @RequiresStudyRole({StudyRole.STUDY_ADMIN, StudyRole.STUDY_OPERATOR})
@@ -92,6 +110,7 @@ public class ParticipantsApiV1Controller implements ParticipantsApi {
     public ResponseEntity<ParticipantDTO> getParticipant(Long studyId, Integer participantId) {
         return ResponseEntity.ok(
                 toParticipantDTO(service.getParticipant(studyId, participantId))
+                        .dataHealthIndicator(getDataHealthIndicator(studyId, participantId))
         );
     }
 

--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/StudyApiV1Controller.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/StudyApiV1Controller.java
@@ -8,6 +8,7 @@
  */
 package io.redlink.more.studymanager.controller.studymanager;
 
+import io.redlink.more.studymanager.api.v1.model.OccurredObservationDTO;
 import io.redlink.more.studymanager.api.v1.model.StatusChangeDTO;
 import io.redlink.more.studymanager.api.v1.model.StudyDTO;
 import io.redlink.more.studymanager.api.v1.webservices.StudiesApi;
@@ -18,6 +19,8 @@ import io.redlink.more.studymanager.model.StudyRole;
 import io.redlink.more.studymanager.model.transformer.StudyTransformer;
 import io.redlink.more.studymanager.service.OAuth2AuthenticationService;
 import io.redlink.more.studymanager.service.StudyService;
+
+import java.time.Instant;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -105,4 +108,5 @@ public class StudyApiV1Controller implements StudiesApi {
                         .map(StudyTransformer::toStudyDTO_V1)
         );
     }
+
 }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/OccurredObservationTransformer.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/OccurredObservationTransformer.java
@@ -1,0 +1,34 @@
+package io.redlink.more.studymanager.model.transformer;
+
+import io.redlink.more.studymanager.api.v1.model.OccurredObservationDTO;
+import io.redlink.more.studymanager.controller.studymanager.OccurredObservationsApiV1Controller;
+import io.redlink.more.studymanager.core.datavalidity.ObservationDataState;
+import io.redlink.more.studymanager.properties.GatewayProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OccurredObservationTransformer {
+    private static final Logger log = LoggerFactory.getLogger(OccurredObservationTransformer.class);
+
+    public static OccurredObservationDTO toOccurredObservationDTO_V1(OccurredObservationsApiV1Controller.OccurredObservationData ood, GatewayProperties gatewayProperties) {
+        return new OccurredObservationDTO()
+                .studyId(ood.occurredObservation().studyId())
+                .observation(ObservationTransformer.toObservationDTO_V1(ood.observation()))
+                .participant(ParticipantTransformer.toParticipantDTO_V1(ood.participant(), gatewayProperties))
+                .start(ood.occurredObservation().start())
+                .end(ood.occurredObservation().end())
+                .state(!ood.occurredObservation().dataValid() ?
+                        OccurredObservationDTO.StateEnum.MISSING :
+                        toStateEnum(ood.occurredObservation().dataState()));
+    }
+
+
+    private static OccurredObservationDTO.StateEnum toStateEnum(ObservationDataState state) {
+        try {
+            return OccurredObservationDTO.StateEnum.valueOf(state.name());
+        } catch (IllegalArgumentException e) {
+            log.error("Unable to convert ObservationDataState {} to OccurredObservationDTO.StateEnum! Use MISSING as fallback.", state.name(), e);
+            return OccurredObservationDTO.StateEnum.MISSING;
+        }
+    }
+}

--- a/studymanager/src/main/resources/openapi/StudyManagerAPI.yaml
+++ b/studymanager/src/main/resources/openapi/StudyManagerAPI.yaml
@@ -615,6 +615,48 @@ paths:
         '500':
           description: Error
 
+  /studies/{studyId}/occuredObserrvations:
+    get:
+      tags:
+        - occuredObserrvations
+      description: List of occurred observations of one specific participant
+      operationId: listOccurredObservations
+      parameters:
+        - $ref: '#/components/parameters/StudyId'
+        - name: participant
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: observation
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: from
+          in: query
+          description: default is entire time
+          schema:
+            type: string
+            format: date-time
+        - name: to
+          in: query
+          description: default is now
+          schema:
+            type: string
+            format: date-time
+      responses:
+        '200':
+          description: operation successful
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/OccurredObservation'
+        '404':
+          description: Not found
+
   /studies/{studyId}/observations:
     post:
       tags:
@@ -1326,7 +1368,7 @@ paths:
                   $ref: '#/components/schemas/DataPoint'
         '404':
           description: not found
-          
+
   /auditlog/study/{studyId}/export:
     parameters:
       - $ref: '#/components/parameters/StudyId'
@@ -1647,6 +1689,12 @@ components:
           readOnly: true
         status:
           $ref: '#/components/schemas/ParticipantStatus'
+        dataHealthIndicator:
+          type: string
+          enum:
+            - 'green'
+            - 'orange'
+            - 'red'
         start:
           type: string
           format: date-time
@@ -1715,6 +1763,33 @@ components:
           type: boolean
           default: false
 
+    OccurredObservation:
+      type: object
+      properties:
+        studyId:
+          $ref: '#/components/schemas/StudyId'
+        participant:
+          $ref: '#/components/schemas/Participant'
+        observation:
+          $ref: '#/components/schemas/Observation'
+        start:
+          type: string
+          format: date-time
+        end:
+          type: string
+          format: date-time
+        state:
+          type: string
+          enum:
+            - missing
+            - completed
+            - incomplete
+            - ongoing
+      required:
+        - studyId
+        - start
+        - end
+        - state
 
     StudyTimeline:
       type: object

--- a/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/ParticipantControllerTest.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/ParticipantControllerTest.java
@@ -15,6 +15,7 @@ import io.redlink.more.studymanager.model.Participant;
 import io.redlink.more.studymanager.model.PlatformRole;
 import io.redlink.more.studymanager.properties.GatewayProperties;
 import io.redlink.more.studymanager.service.OAuth2AuthenticationService;
+import io.redlink.more.studymanager.service.OccurredObservationService;
 import io.redlink.more.studymanager.service.ParticipantService;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -22,6 +23,8 @@ import java.time.Instant;
 import java.util.EnumSet;
 import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Stream;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -57,6 +60,9 @@ class ParticipantControllerTest {
     @MockitoBean
     OAuth2AuthenticationService oAuth2AuthenticationService;
 
+    @MockitoBean
+    OccurredObservationService occurredObservationService;
+
     @Autowired
     private GatewayProperties gatewayProperties;
 
@@ -84,6 +90,7 @@ class ParticipantControllerTest {
                         EnumSet.allOf(PlatformRole.class)
                 )
         );
+        when(occurredObservationService.streamOccurredObservations(anyLong(),any(),any(),any(), any())).thenReturn(Stream.of());
     }
 
     @Test

--- a/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/ParticipantControllerTest.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/ParticipantControllerTest.java
@@ -38,9 +38,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -90,7 +88,7 @@ class ParticipantControllerTest {
                         EnumSet.allOf(PlatformRole.class)
                 )
         );
-        when(occurredObservationService.streamOccurredObservations(anyLong(),any(),any(),any(), any())).thenReturn(Stream.of());
+        when(occurredObservationService.streamOccurredObservations(anyLong(), any(), any(), anyBoolean(), any())).thenReturn(Stream.of());
     }
 
     @Test


### PR DESCRIPTION
* DataValidity is checkt for all OccurredObservations every 5 minutes
* There is a default implementation for Observation component that checks if any data is present for Observation, Participant and within the timespan of the OccurredObservation. This Method needs to be overridden by specific Observations to make further validations
    * Specific implementation for the SimpleQuestionObservation that checks if an answer is present and that only a single result is present for the given time span
* Validation is done generically based on the MeasurementSet define by the ObservationFactory by aggregating data in the elastic search index based on Measurements defined the MeasurementSet. In addition an aggregation over the timestamps of the measurements and the number of documents is built

#621; DataValidity Webservice Extension

* This also implements the Webservices defined for the first version of the DataValidity UI
    * when listing participants the service now returns an data health indicator
    * a new Controller for OccurredObservations allows to list OccurredObservations vor a study for an participant and/or an observation