### PR TITLE
#353 fix Data Validation check

### DIFF
--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/component/Observation.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/component/Observation.java
@@ -74,7 +74,7 @@ public abstract class Observation<C extends ObservationProperties> extends Compo
         if(observationDataSummary == null) { //null indicates some problem. This will cause the check to be repeated
             return new ObservationValidationResult(false, ObservationDataState.MISSING);
         }
-        if(observationDataSummary.numDocs() < 0) { //no data
+        if(observationDataSummary.numDocs() <= 0) { //no data
             return new ObservationValidationResult(false, ObservationDataState.MISSING);
         }
         //the default implementation assumes an observation to be complete if any data are availale

--- a/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/QuestionObservation.java
+++ b/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/QuestionObservation.java
@@ -186,12 +186,12 @@ public class QuestionObservation<C extends ObservationProperties> extends Observ
         if(observationDataSummary == null) { //null indicates some problem. This will cause the check to be repeated
             return new ObservationValidationResult(false, ObservationDataState.MISSING);
         }
-        if(observationDataSummary.numDocs() < 0) { //no data
+        if(observationDataSummary.numDocs() <= 0) { //no data
             return new ObservationValidationResult(false, ObservationDataState.MISSING);
         } else if(observationDataSummary.numDocs() > 1) {
             //only a single answer is allowed
             return new ObservationValidationResult(true, ObservationDataState.COMPLETE);
-        } else {
+        } else { //exactly one result
             MeasurementSummary answerMeasurementSummary = observationDataSummary.measurements().stream()
                     .filter(it -> QuestionObservationFactory.FIELD_ANSWER.equals(it.getMeasurement().getId()))
                     .findFirst()

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/scheduling/ValidateActiveObservationDataCron.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/scheduling/ValidateActiveObservationDataCron.java
@@ -124,7 +124,7 @@ public class ValidateActiveObservationDataCron {
         final OccurredObservation updatedOccurredObservation;
         if(validationResults != null) {
             var validationResult = ctx.observationComponent.validateData(ctx.occurrence.start(), ctx.occurrence.end(), validationResults);
-            log.debug("validated {}: results: {}, state: {}", ctx.occurrence, validationResults, validationResult);
+            log.trace("validated {}: results: {}, state: {}", ctx.occurrence, validationResults, validationResult);
             updatedOccurredObservation = new OccurredObservation(
                     ctx.occurrence.studyId(),
                     ctx.occurrence.observationId(),


### PR DESCRIPTION
The check for numDocs was changed from `< 0 ` to `<= 0`. Now occurred observations with zero data are correctly marked as MISSING