### PR TITLE
#353: Bugfix - QuestionObservation data validation

### DIFF
--- a/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/QuestionObservation.java
+++ b/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/QuestionObservation.java
@@ -197,8 +197,8 @@ public class QuestionObservation<C extends ObservationProperties> extends Observ
                     .findFirst()
                     .orElse(null);
             boolean hasAnswers = answerMeasurementSummary != null &&
-                    answerMeasurementSummary.getStringResult().values().stream().noneMatch(it -> it.value() != null);
-            return new ObservationValidationResult(!hasAnswers, ObservationDataState.COMPLETE);
+                    answerMeasurementSummary.getStringResult().values().stream().noneMatch(it -> it.value() == null);
+            return new ObservationValidationResult(!hasAnswers, hasAnswers ? ObservationDataState.COMPLETE : ObservationDataState.MISSING);
         }
     }
 }

--- a/studymanager-observation/src/test/java/io/redlink/more/studymanager/component/observation/lime/QuestionObservationTest.java
+++ b/studymanager-observation/src/test/java/io/redlink/more/studymanager/component/observation/lime/QuestionObservationTest.java
@@ -1,0 +1,76 @@
+package io.redlink.more.studymanager.component.observation.lime;
+
+import io.redlink.more.studymanager.component.observation.QuestionObservation;
+import io.redlink.more.studymanager.component.observation.QuestionObservationFactory;
+import io.redlink.more.studymanager.core.datavalidity.*;
+import io.redlink.more.studymanager.core.measurement.Measurement;
+import io.redlink.more.studymanager.core.properties.ObservationProperties;
+import io.redlink.more.studymanager.core.sdk.MoreObservationSDK;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+
+public class QuestionObservationTest {
+
+
+    @Test
+    public void testValidation(){
+        MoreObservationSDK sdk = mock(MoreObservationSDK.class);
+        ObservationProperties properties = mock(ObservationProperties.class);
+
+        Instant start = Instant.now().truncatedTo(ChronoUnit.HOURS).minus(1, ChronoUnit.HOURS);
+        Instant end = start.plus(1, ChronoUnit.HOURS);
+        Instant stored = start.plus(45, ChronoUnit.MINUTES);
+
+        QuestionObservation questionObservation = new QuestionObservation(sdk, properties);
+
+        var answerSummary = new MeasurementSummary(
+                new Measurement(QuestionObservationFactory.FIELD_ANSWER, Measurement.Type.STRING));
+        answerSummary.setStringResult(new StringMeasurementSummary(List.of(new StringFieldValue("Antwort 1", 1))));
+        ObservationDataSummary validSummary = new ObservationDataSummary(
+                1,
+                new DateMeasurementSummary(stored,stored,0L),
+                List.of(answerSummary)
+        );
+        var result = questionObservation.validateData(start, end, validSummary);
+        Assertions.assertFalse(result.invalid());
+        Assertions.assertEquals(ObservationDataState.COMPLETE, result.state());
+
+        ObservationDataSummary invalidMultipleAnswersSummary = new ObservationDataSummary(
+                2,
+                new DateMeasurementSummary(stored,stored,0L),
+                List.of(answerSummary)
+        );
+        result = questionObservation.validateData(start, end, invalidMultipleAnswersSummary);
+        Assertions.assertTrue(result.invalid());
+        Assertions.assertEquals(ObservationDataState.COMPLETE, result.state());
+
+        ObservationDataSummary noAnswersSummary = new ObservationDataSummary(
+                0,
+                null,
+                null
+        );
+        result = questionObservation.validateData(start, end, noAnswersSummary);
+        Assertions.assertFalse(result.invalid());
+        Assertions.assertEquals(ObservationDataState.MISSING, result.state());
+
+        var nullAnswerSummary = new MeasurementSummary(
+                new Measurement(QuestionObservationFactory.FIELD_ANSWER, Measurement.Type.STRING));
+        nullAnswerSummary.setStringResult(new StringMeasurementSummary(List.of(new StringFieldValue(null, 1))));
+        ObservationDataSummary invalidAnswerSummary = new ObservationDataSummary(
+                1,
+                new DateMeasurementSummary(stored,stored,0L),
+                List.of(nullAnswerSummary)
+        );
+        result = questionObservation.validateData(start, end, invalidAnswerSummary);
+        Assertions.assertTrue(result.invalid());
+        Assertions.assertEquals(ObservationDataState.MISSING, result.state());
+
+
+    }
+}


### PR DESCRIPTION
fixed a bug where the check for the answer property was the wrong way around. Also refined the ObservationDataState to missing if none of the present answers provided a valid result. This does not really make a difference as those OccurredObservations would be marked as invalid anyways. Added a UnitTest for the validation