### PR TITLE
#481: Reverted the limesurvey answer storage to the short id form

### DIFF
--- a/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyObservation.java
+++ b/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyObservation.java
@@ -126,7 +126,7 @@ public class LimeSurveyObservation<C extends ObservationProperties> extends Obse
             return false;
         }
 
-        Optional<Map<String, Object>> answer = limeSurveyRequestService.getAnswerPlaintext(token, surveyId, savedId);
+        Optional<Map<String, Object>> answer = limeSurveyRequestService.getAnswer(token, surveyId, savedId);
         if (answer.isEmpty() || answer.get().isEmpty()) {
             LOGGER.warn("No answer found for token while writing datapoints for survey {} and savedId {} (participantId: {})", surveyId, savedId, participantId.get());
             return false;


### PR DESCRIPTION
<img width="2603" height="162" alt="image" src="https://github.com/user-attachments/assets/b96f3d37-004c-42fd-a3cc-464b624d2339" />
Long vs short form for a more complex study