### PR TITLE
#280: OccurredObservation by start/end time

### DIFF
--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/repository/OccurredObservationRepository.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/repository/OccurredObservationRepository.java
@@ -22,6 +22,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -56,6 +57,8 @@ public class OccurredObservationRepository {
                         AND (:observation_id::INT IS NULL OR oo.observation_id = :observation_id)
                         AND (:data_valid::BOOLEAN IS NULL OR oo.data_valid = :data_valid)
                         AND (:data_states::observation_data_state[] IS NULL OR oo.data_state = ANY(:data_states::observation_data_state[]))
+                        AND (:start_time::TIMESTAMPTZ IS NULL OR oo.start >= :start_time)
+                        AND (:end_time::TIMESTAMPTZ IS NULL OR oo."end" <= :end_time)
             """;
 
     private static final String FIND_LAST_START_TIME = """
@@ -131,12 +134,23 @@ public class OccurredObservationRepository {
             Boolean dataValid,
             Set<ObservationDataState> dataStates
     ) {
+        return listOccurredObservations(studyId, participantId, observationId, dataValid, dataStates, null, null);
+    }
+    public Stream<OccurredObservation> listOccurredObservations(
+            Long studyId, Integer participantId, Integer observationId,
+            Boolean dataValid,
+            Set<ObservationDataState> dataStates,
+            Instant startTime,
+            Instant endTime
+    ) {
         return namedTemplate.queryForStream(LIST_OCCURRED_OBSERVATION,
                 new MapSqlParameterSource("study_id", studyId)
                         .addValue("participant_id", participantId)
                         .addValue("observation_id", observationId)
                         .addValue("data_valid", dataValid)
-                        .addValue("data_states", dataStates == null ? null : dataStates.stream().map(ObservationDataState::getValue).toArray(String[]::new)),
+                        .addValue("data_states", dataStates == null ? null : dataStates.stream().map(ObservationDataState::getValue).toArray(String[]::new))
+                        .addValue("start_time", startTime == null ? null : startTime.atOffset(ZoneOffset.UTC))
+                        .addValue("end_time", endTime == null ? null : endTime.atOffset(ZoneOffset.UTC)),
                 getOccurredObservationRowMapper());
     }
 

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/OccurredObservationService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/OccurredObservationService.java
@@ -106,6 +106,26 @@ public class OccurredObservationService {
                 includeInvalid ? null : true,
                 observationDataStates == null ? EnumSet.allOf(ObservationDataState.class) : observationDataStates);
     }
+    /**
+     * Stream over all occurred observations for a participant of a study, where data is still missing (not in
+     * {@link ObservationDataState#COMPLETE})
+     * @param studyId the study id
+     * @param participantId the participant id or <code>null</code> as wildcard
+     * @param observationId the observation id  or <code>null</code> as wildcard
+     * @param startTime if present the start of the occurred observation is &gt;= the parsed value
+     * @param endTime if present the end of the occurred observation is &lt;= the parsed value
+     * @param includeInvalid if occurred observations marked as having invalid data are included
+     * @param observationDataStates the states to include or <code>null</code> to include all
+     * @return a stream over all ongoing or occurred observations where data are still missing
+     */
+    public Stream<OccurredObservation> streamOccurredObservations(long studyId, Integer participantId, Integer observationId, Instant startTime, Instant endTime, boolean includeInvalid, Set<ObservationDataState> observationDataStates) {
+        return repository.listOccurredObservations(
+                studyId, participantId, observationId,
+                includeInvalid ? null : true,
+                observationDataStates == null ? EnumSet.allOf(ObservationDataState.class) : observationDataStates,
+                startTime,
+                endTime);
+    }
 
     public void deleteOccurredObservations(Long studyId) {
         repository.deleteOccurredObservations(studyId);

--- a/studymanager-services/src/test/java/io/redlink/more/studymanager/repository/OccurredObservationRepositoryTest.java
+++ b/studymanager-services/src/test/java/io/redlink/more/studymanager/repository/OccurredObservationRepositoryTest.java
@@ -62,6 +62,10 @@ class OccurredObservationRepositoryTest {
     @BeforeEach
     void deleteAll() {
         occurredObservationRepository.clear();
+        observationRepository.clear();
+        participantRepository.clear();
+        studyGroupRepository.clear();
+        studyRepository.clear();
     }
 
     @Test

--- a/studymanager-services/src/test/java/io/redlink/more/studymanager/repository/OccurredObservationRepositoryTest.java
+++ b/studymanager-services/src/test/java/io/redlink/more/studymanager/repository/OccurredObservationRepositoryTest.java
@@ -246,6 +246,54 @@ class OccurredObservationRepositoryTest {
         assertThat(vIPoos).hasSize(2);
         assertThat(vIPoos).containsExactlyInAnyOrder(ooO1P1T, ooO2P2Y);
 
+        // Test startTime filter only (start >= startTime) → should exclude yesterday's records
+        var startTimeFiltered = occurredObservationRepository.listOccurredObservations(
+                studyId, participant.getParticipantId(), null, null, null,
+                startTime, null).toList();
+
+        assertThat(startTimeFiltered)
+                .as("startTime filter should return only observations starting on/after startTime (today)")
+                .hasSize(1)
+                .containsExactlyInAnyOrder(ooO1P1T);
+
+        // Test endTime filter only (end <= endTime2) → should only include the earlier observation2 records
+        var endTimeFiltered = occurredObservationRepository.listOccurredObservations(
+                studyId, participant.getParticipantId(), null, null, null,
+                null, endTime.minus(1, ChronoUnit.DAYS)).toList();
+
+        assertThat(endTimeFiltered)
+                .as("endTime filter should return only observations ending on/before (endTime - 1DAY)")
+                .hasSize(2)
+                .containsExactlyInAnyOrder(ooO1P1Y, ooO2P1Y);
+
+        // Test both startTime and endTime together (narrow window around today's observation 1)
+        var timeRangeFiltered = occurredObservationRepository.listOccurredObservations(
+                studyId, participant.getParticipantId(), null, null, null,
+                startTime.minus(1, ChronoUnit.DAYS), endTime).toList();
+
+        assertThat(timeRangeFiltered)
+                .as("combined (startTime - 1Day) + endTime should return two observations")
+                .hasSize(2)
+                .containsExactlyInAnyOrder(ooO1P1Y, ooO2P1T);
+
+        // Test time range that should return no results
+        var futureRange = occurredObservationRepository.listOccurredObservations(
+                studyId, null, null, null, null,
+                startTime.plus(5, ChronoUnit.DAYS), null).toList();
+        assertThat(futureRange)
+                .as("future startTime should return empty result")
+                .isEmpty();
+
+        // Test time range combined with other filters (participant + dataValid)
+        var combinedFilter = occurredObservationRepository.listOccurredObservations(
+                studyId, participant2.getParticipantId(), null, true, null,
+                startTime, endTime.plus(1, ChronoUnit.HOURS)).toList();
+
+        assertThat(combinedFilter)
+                .as("time range + participant + dataValid filter")
+                .hasSize(1)
+                .containsExactly(ooO1P2T);
+
         //Test Query for last Start Time
         var lastStartTimeStudy = occurredObservationRepository.getLatestStartTime(studyId, null, null, null, null);
         assertThat(lastStartTimeStudy).isNotNull();


### PR DESCRIPTION
Extenseion related to [DataGateway#280](https://github.com/MORE-Platform/more-data-gateway/issues/280)
This extension is needed for the data health service of the data gateway. Added the functionality also to the OccurredObservation repo & service of the study manager backend so that it is possible to write component tests!