### PR TITLE
#479: DataHealth for LimeObservation

### DIFF
--- a/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyObservation.java
+++ b/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyObservation.java
@@ -8,8 +8,14 @@
  */
 package io.redlink.more.studymanager.component.observation.lime;
 
+import io.redlink.more.studymanager.component.observation.QuestionObservationFactory;
 import io.redlink.more.studymanager.component.observation.lime.model.ParticipantData;
+import io.redlink.more.studymanager.component.observation.utils.QuestionObservationUtils;
 import io.redlink.more.studymanager.core.component.Observation;
+import io.redlink.more.studymanager.core.datavalidity.MeasurementSummary;
+import io.redlink.more.studymanager.core.datavalidity.ObservationDataState;
+import io.redlink.more.studymanager.core.datavalidity.ObservationDataSummary;
+import io.redlink.more.studymanager.core.datavalidity.ObservationValidationResult;
 import io.redlink.more.studymanager.core.exception.ConfigurationValidationException;
 import io.redlink.more.studymanager.core.properties.ObservationProperties;
 import io.redlink.more.studymanager.core.sdk.MoreObservationSDK;
@@ -19,6 +25,7 @@ import io.redlink.more.studymanager.core.validation.ValidationIssue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -149,6 +156,41 @@ public class LimeSurveyObservation<C extends ObservationProperties> extends Obse
                                 .orElse(false)
                 )
                 .findFirst();
+    }
+
+    @Override
+    public ObservationValidationResult validateData(Instant start, Instant end, ObservationDataSummary observationDataSummary) {
+        if(observationDataSummary == null || observationDataSummary.measurements() == null) {
+            return  new ObservationValidationResult(false, ObservationDataState.MISSING);
+        }
+        //(1) Use the default single Answer utility method
+        var validationResult = QuestionObservationUtils.validateSingleAnswerObservation(
+                observationDataSummary,
+                LimeSurveyObservationFactory.MEASUREMENT_SEED //NOTE: This utility method only works with STRING fields!!
+        );
+        //(2) Check of the ID property is present
+        MeasurementSummary answerMeasurementSummary = observationDataSummary.measurements().stream()
+                .filter(it -> LimeSurveyObservationFactory.MEASUREMENT_ID.equals(it.getMeasurement().getId()))
+                .findFirst()
+                .orElse(null);
+        //check that the field is present on all documents
+        boolean hasId = answerMeasurementSummary != null
+                && answerMeasurementSummary.getNumericResult() != null
+                && answerMeasurementSummary.getNumericResult().missing() == 0;
+
+        //(3) Adapt the validation result where necessary
+        if(!validationResult.invalid() && validationResult.state() == ObservationDataState.COMPLETE && !hasId) {
+            //The required field seed is missing in the results!
+            return new ObservationValidationResult(
+                    true,
+                    ObservationDataState.INCOMPLETE
+            );
+        } else if(validationResult.state() == ObservationDataState.MISSING && hasId){
+            //if seed is missing, but ID is present ... return INCOMPLETE instead of MISSING as result
+            return new ObservationValidationResult(validationResult.invalid(), ObservationDataState.INCOMPLETE);
+        } else { //just return the original validation format
+            return validationResult;
+        }
     }
 
     private void updateParticipants(ParticipantData participant) {

--- a/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyObservationFactory.java
+++ b/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyObservationFactory.java
@@ -14,6 +14,7 @@ import io.redlink.more.studymanager.core.exception.ApiCallException;
 import io.redlink.more.studymanager.core.exception.ConfigurationValidationException;
 import io.redlink.more.studymanager.core.factory.ComponentFactoryProperties;
 import io.redlink.more.studymanager.core.factory.ObservationFactory;
+import io.redlink.more.studymanager.core.measurement.Measurement;
 import io.redlink.more.studymanager.core.measurement.MeasurementSet;
 import io.redlink.more.studymanager.core.model.User;
 import io.redlink.more.studymanager.core.properties.ObservationProperties;
@@ -22,6 +23,7 @@ import io.redlink.more.studymanager.core.properties.model.Value;
 import io.redlink.more.studymanager.core.sdk.MoreObservationSDK;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public class LimeSurveyObservationFactory<C extends LimeSurveyObservation<P>, P extends ObservationProperties>
         extends ObservationFactory<C, P> {
@@ -33,14 +35,22 @@ public class LimeSurveyObservationFactory<C extends LimeSurveyObservation<P>, P 
             .setImmutable(true);
 
     private static final List<Value> properties = List.of(
-            /* TODO enable Autocomplete in FE
-            new AutocompleteValue("limeSurveyId", "surveys")
-                    .setName("Survey")
-                    .setDescription("An existing survey")
-                    .setRequired(true)
-             */
             limeSurveyId
     );
+
+    public static String MEASUREMENT_ID = "id";
+    public static String MEASUREMENT_SEED = "seed";
+    /**
+     * This measurementSet includes the id and seed of the LimeSurvey. All
+     * survey specific information are stored under the survey keys. Those keys
+     * are survey specific and can be obtained via the survey data from limesurvey
+     */
+    private static MeasurementSet LIMESURVEY_METADATA = new MeasurementSet(
+            "LIMESURVEY", Set.of(
+            new Measurement(MEASUREMENT_ID, Measurement.Type.INTEGER),
+            new Measurement(MEASUREMENT_SEED, Measurement.Type.STRING))
+    );
+
 
     private LimeSurveyRequestService limeSurveyRequestService;
 
@@ -109,6 +119,6 @@ public class LimeSurveyObservationFactory<C extends LimeSurveyObservation<P>, P 
 
     @Override
     public MeasurementSet getMeasurementSet() {
-        return GenericMeasurementSets.NOT_SPECIFIED;
+        return LIMESURVEY_METADATA;
     }
 }

--- a/studymanager-observation/src/test/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyObservationTest.java
+++ b/studymanager-observation/src/test/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyObservationTest.java
@@ -1,10 +1,23 @@
 package io.redlink.more.studymanager.component.observation.lime;
 
+import io.redlink.more.studymanager.component.observation.QuestionObservation;
+import io.redlink.more.studymanager.component.observation.QuestionObservationFactory;
+import io.redlink.more.studymanager.core.datavalidity.DateMeasurementSummary;
+import io.redlink.more.studymanager.core.datavalidity.FieldValue;
+import io.redlink.more.studymanager.core.datavalidity.MeasurementSummary;
+import io.redlink.more.studymanager.core.datavalidity.NumericMeasurementSummary;
+import io.redlink.more.studymanager.core.datavalidity.ObservationDataState;
+import io.redlink.more.studymanager.core.datavalidity.ObservationDataSummary;
+import io.redlink.more.studymanager.core.datavalidity.StringMeasurementSummary;
+import io.redlink.more.studymanager.core.measurement.Measurement;
 import io.redlink.more.studymanager.core.properties.ObservationProperties;
 import io.redlink.more.studymanager.core.sdk.MoreObservationSDK;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -34,4 +47,74 @@ public class LimeSurveyObservationTest {
 
         Assertions.assertTrue(expectedError);
     }
-}
+
+    @Test
+    public void testValidation() {
+        MoreObservationSDK sdk = mock(MoreObservationSDK.class);
+        ObservationProperties properties = mock(ObservationProperties.class);
+
+        Instant start = Instant.now().truncatedTo(ChronoUnit.HOURS).minus(1, ChronoUnit.HOURS);
+        Instant end = start.plus(1, ChronoUnit.HOURS);
+        Instant stored = start.plus(45, ChronoUnit.MINUTES);
+
+        LimeSurveyObservation questionObservation = new LimeSurveyObservation(sdk, properties, null);
+
+        var seedSummary = new MeasurementSummary(
+                new Measurement(LimeSurveyObservationFactory.MEASUREMENT_SEED, Measurement.Type.STRING));
+        seedSummary.setStringResult(new StringMeasurementSummary(List.of(new FieldValue<>("seed_12345", 1))));
+        var idMs = new MeasurementSummary(
+                new Measurement(LimeSurveyObservationFactory.MEASUREMENT_ID, Measurement.Type.INTEGER));
+        idMs.setNumericResult(new NumericMeasurementSummary(1.0,1.0, 1.0, 1.0, 0));
+        ObservationDataSummary validSummary = new ObservationDataSummary(
+                1,
+                new DateMeasurementSummary(stored, stored, 0L),
+                List.of(idMs, seedSummary)
+        );
+        var result = questionObservation.validateData(start, end, validSummary);
+        Assertions.assertFalse(result.invalid());
+        Assertions.assertEquals(ObservationDataState.COMPLETE, result.state());
+
+        ObservationDataSummary invalidMultipleAnswersSummary = new ObservationDataSummary(
+                2,
+                new DateMeasurementSummary(stored, stored, 0L),
+                List.of(idMs, seedSummary)
+        );
+        result = questionObservation.validateData(start, end, invalidMultipleAnswersSummary);
+        Assertions.assertTrue(result.invalid());
+        Assertions.assertEquals(ObservationDataState.COMPLETE, result.state());
+
+        ObservationDataSummary noAnswersSummary = new ObservationDataSummary(
+                0,
+                null,
+                null
+        );
+        result = questionObservation.validateData(start, end, noAnswersSummary);
+        Assertions.assertFalse(result.invalid());
+        Assertions.assertEquals(ObservationDataState.MISSING, result.state());
+
+        var nullSeedMs = new MeasurementSummary(
+                new Measurement(LimeSurveyObservationFactory.MEASUREMENT_SEED, Measurement.Type.STRING));
+        nullSeedMs.setStringResult(new StringMeasurementSummary(List.of(new FieldValue<String>(null, 1))));
+        ObservationDataSummary nullSeedSummary = new ObservationDataSummary(
+                1,
+                new DateMeasurementSummary(stored, stored, 0L),
+                List.of(idMs, nullSeedMs)
+        );
+        result = questionObservation.validateData(start, end, nullSeedSummary);
+        Assertions.assertTrue(result.invalid());
+        Assertions.assertEquals(ObservationDataState.INCOMPLETE, result.state());
+
+        var missingIdMs = new MeasurementSummary(
+                new Measurement(LimeSurveyObservationFactory.MEASUREMENT_ID, Measurement.Type.INTEGER));
+        missingIdMs.setNumericResult(new NumericMeasurementSummary(0.0f, 0.0f, 0.0f, 0.0f, 1));
+        ObservationDataSummary missingIdSummary = new ObservationDataSummary(
+                1,
+                new DateMeasurementSummary(stored, stored, 0L),
+                List.of(missingIdMs, seedSummary)
+        );
+        result = questionObservation.validateData(start, end, missingIdSummary);
+        Assertions.assertTrue(result.invalid());
+        Assertions.assertEquals(ObservationDataState.INCOMPLETE, result.state());
+
+
+    }}


### PR DESCRIPTION
#479 adds support for DataHealth for LimeObservation:

* Checks that only a single Survey is present for the Observation
* Checks that the `id` and `seed` data are present for the Observation

NOTE: Checks for actual Survey Data are not implemented as those would require API calls to the Lime Server and this is not feasible for periodic data health check. In addition their is no guarantee that a LimeSurvey is still available and unmodified on the server.