### PR TITLE
#491: Multi Sudy/Observation LimeSurvey support

### DIFF
--- a/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyObservation.java
+++ b/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyObservation.java
@@ -24,6 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
+import java.util.AbstractMap;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -33,6 +35,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class LimeSurveyObservation<C extends ObservationProperties> extends Observation<C> {
+
+    private static final String LIME_SURVEY_USER_TEMPLATE = "study_%s-observation_%s-participant_%s";
 
     public static final String LIME_SURVEY_ID = "limeSurveyId";
     private static final String LIME_SURVEY_TOKEN_KEY = "token";
@@ -45,51 +49,97 @@ public class LimeSurveyObservation<C extends ObservationProperties> extends Obse
         this.limeSurveyRequestService = limeSurveyRequestService;
     }
 
+    private String getLimeSurveyUser(int participantId){
+        return String.format(LIME_SURVEY_ID,
+                sdk.getStudyId(),
+                sdk.getObservationId(),
+                participantId);
+    }
+
+    private Integer getParticipantId(ParticipantData limeSurveyParticipant){
+        if(limeSurveyParticipant == null || limeSurveyParticipant.firstname() == null){
+            return null;
+        }
+        //backward compatibility: in older Versions this used just the participantId as first name
+        try {
+            return Integer.parseInt(limeSurveyParticipant.firstname());
+        } catch (NumberFormatException e){/* ignore*/}
+        //the new syntax is
+        //    firstname: `study_<study_id>-observation_<observation_id>-participant_<participant_id>`
+        //    lastname: `more`
+        String participantPrefix = String.format(LIME_SURVEY_USER_TEMPLATE, sdk.getStudyId(), sdk.getObservationId(), "");
+        if("more".equals(limeSurveyParticipant.lastname()) &&
+                limeSurveyParticipant.firstname().startsWith(participantPrefix)){
+            try {
+                return Integer.parseInt(limeSurveyParticipant.firstname().substring(participantPrefix.length()));
+            } catch (NumberFormatException e) {
+                /*ignroe*/
+            }
+        }
+        return null;
+    }
+
+    private ParticipantData.ParticipantInfo toParticipantInfo(Integer participantId){
+        return new ParticipantData.ParticipantInfo(
+                String.format(LIME_SURVEY_USER_TEMPLATE, sdk.getStudyId(), sdk.getObservationId(), participantId),
+                "more"
+        );
+    }
+
+
     @Override
     public void activate() {
-        Optional<String> surveyId = checkAndGetSurveyId();
-        if (surveyId.isEmpty()) {
-            LOGGER.error("Lime Survey ID not present!");
-            throw new IllegalStateException("Lime Survey ID not present!");
-        }
+        String surveyId = checkAndGetSurveyId()
+                .orElseThrow(() -> {
+                    LOGGER.error("Lime Survey ID not present (study: {}, Observation: {})!", sdk.getStudyId(), sdk.getObservationId());
+                    return new IllegalStateException(String.format("No survey id provided for study %s and Observation %s",
+                            sdk.getStudyId(), sdk.getObservationId()));
+                });
 
         Set<Integer> participantIds = sdk.participantIds(MorePlatformSDK.ParticipantFilter.ALL);
-        List<ParticipantData> limeParticipants = limeSurveyRequestService.listParticipants(surveyId.get(), 0, Math.max(1, participantIds.size()));
+        //NOTE: This should use paging and just return all participants, as one survey can be used by multiple
+        //      studies/observations one can not really say how many participants are present
+        //      If it selects not all this will create duplicate participants on every activation of the study!!
+        Integer limit = Math.max(1000, participantIds.size()*2);
+        List<ParticipantData> limeParticipants = limeSurveyRequestService.listParticipants(surveyId, 0, limit);
 
-        Set<String> existingParticipantIds = limeParticipants.stream()
-                .map(ParticipantData::firstname)
-                .filter(Objects::nonNull)
-                .collect(Collectors.toSet());
+        //look for Limesurvey survey participants that where created for this observation/study
+        Map<Integer, ParticipantData> existingParticipantIds = limeParticipants.stream()
+                .map(it -> new AbstractMap.SimpleEntry<>(getParticipantId(it), it))
+                .filter(entry -> entry.getKey() != null)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-        Set<Integer> participantTokenIdsToDelete = limeParticipants.stream()
-                .filter(participant ->
-                        participant.tid() != null
-                                && isNumeric(participant.firstname())
-                                && !participantIds.contains(Integer.parseInt(participant.firstname())))
+        //filter existingParticipants that are no longer present in the study
+        Map<Integer, ParticipantData> participantsToDelete = existingParticipantIds.entrySet().stream()
+                .filter(entry -> !participantIds.contains(entry.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        Set<Integer> participantTokenIdsToDelete = participantsToDelete.values().stream()
                 .map(ParticipantData::tid)
                 .collect(Collectors.toSet());
 
-        limeSurveyRequestService.deleteParticipants(surveyId.get(), participantTokenIdsToDelete);
+        limeSurveyRequestService.deleteParticipants(surveyId, participantTokenIdsToDelete);
 
-        Set<Integer> participantsToActivate = participantIds
+        Set<ParticipantData.ParticipantInfo> participantsToActivate = participantIds
                 .stream()
-                .filter(id -> !existingParticipantIds.contains(String.valueOf(id)))
+                .filter(id -> !existingParticipantIds.containsKey(id))
+                .map(this::toParticipantInfo)
                 .collect(Collectors.toSet());
-        List<ParticipantData> activatedParticipants = limeSurveyRequestService.activateParticipants(participantsToActivate, surveyId.get());
+        List<ParticipantData> activatedParticipants = limeSurveyRequestService.activateParticipants(participantsToActivate, surveyId);
 
-        var participantsToUpdate = limeParticipants.stream()
-                .filter(p -> p.firstname() != null)
-                .filter(p -> isNumeric(p.firstname()))
-                .filter(p -> participantIds.contains(Integer.parseInt(p.firstname())));
+        Stream<ParticipantData> participantsToUpdate = existingParticipantIds.entrySet()
+                .stream()
+                .filter(entry -> !participantsToDelete.containsKey(entry.getKey()))
+                .map(Map.Entry::getValue);
 
         Stream.concat(participantsToUpdate, activatedParticipants.stream())
                 .toList()
                 .forEach(this::updateParticipants);
 
         //FIXME:With #476 the setSurveyEndUrl MUST point to the gateway!
-        limeSurveyRequestService.setSurveyEndUrl(surveyId.get(), sdk.getStudyId(), sdk.getObservationId());
-        limeSurveyRequestService.activateSurvey(surveyId.get());
-        sdk.setValue(LIME_SURVEY_ID, surveyId.get());
+        limeSurveyRequestService.setSurveyEndUrl(surveyId, sdk.getStudyId(), sdk.getObservationId());
+        limeSurveyRequestService.activateSurvey(surveyId);
+        sdk.setValue(LIME_SURVEY_ID, surveyId);
     }
 
     protected Optional<String> checkAndGetSurveyId() {
@@ -99,20 +149,22 @@ public class LimeSurveyObservation<C extends ObservationProperties> extends Obse
 
     @Override
     public void deactivate() {
-        // for downwards compatibility (already running studies)
+
         String newSurveyId = properties.getString(LIME_SURVEY_ID);
         String activeSurveyId = sdk.getValue(LIME_SURVEY_ID, String.class).orElse(null);
 
         if (activeSurveyId == null || activeSurveyId.equals(newSurveyId)) {
-            String surveyIdToDeactivate = activeSurveyId != null ? activeSurveyId : newSurveyId;
-            if (surveyIdToDeactivate != null && !surveyIdToDeactivate.isBlank()) {
-                boolean paused = limeSurveyRequestService.deactivateSurvey(surveyIdToDeactivate);
-                if (paused) {
-                    LOGGER.info("Paused LimeSurvey survey {} during observation deactivation", surveyIdToDeactivate);
-                } else {
-                    LOGGER.info("LimeSurvey survey {} could not be paused during observation deactivation; keeping stored survey id for compatibility", surveyIdToDeactivate);
-                }
-            }
+// NOTE: We can no longer deactivate surveys as those might be used by different studies. We do not want to
+//       deactivate a survey used by an other study that is still active!
+//            String surveyIdToDeactivate = activeSurveyId != null ? activeSurveyId : newSurveyId;
+//            if (surveyIdToDeactivate != null && !surveyIdToDeactivate.isBlank()) {
+//                boolean paused = limeSurveyRequestService.deactivateSurvey(surveyIdToDeactivate);
+//                if (paused) {
+//                    LOGGER.info("Paused LimeSurvey survey {} during observation deactivation", surveyIdToDeactivate);
+//                } else {
+//                    LOGGER.info("LimeSurvey survey {} could not be paused during observation deactivation; keeping stored survey id for compatibility", surveyIdToDeactivate);
+//                }
+//            }
             sdk.setValue(LIME_SURVEY_ID, newSurveyId);
         }
     }
@@ -190,7 +242,8 @@ public class LimeSurveyObservation<C extends ObservationProperties> extends Obse
     }
 
     private void updateParticipants(ParticipantData participant) {
-        if (participant == null || participant.firstname() == null || !isNumeric(participant.firstname())) {
+        Integer pid = getParticipantId(participant);
+        if (pid == null) {
             LOGGER.warn("Skipping LimeSurvey participant update for null or incomplete data: {}", participant);
             return;
         }
@@ -199,7 +252,7 @@ public class LimeSurveyObservation<C extends ObservationProperties> extends Obse
             return;
         }
         sdk.mergePropertiesForParticipant(
-                Integer.parseInt(participant.firstname()),
+                pid,
                 new ObservationProperties(
                         Map.of(
                                 LIME_SURVEY_TOKEN_KEY, participant.token(),

--- a/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyObservation.java
+++ b/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyObservation.java
@@ -136,7 +136,6 @@ public class LimeSurveyObservation<C extends ObservationProperties> extends Obse
                 .toList()
                 .forEach(this::updateParticipants);
 
-        //FIXME:With #476 the setSurveyEndUrl MUST point to the gateway!
         limeSurveyRequestService.setSurveyEndUrl(surveyId, sdk.getStudyId(), sdk.getObservationId());
         limeSurveyRequestService.activateSurvey(surveyId);
         sdk.setValue(LIME_SURVEY_ID, surveyId);

--- a/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyRequestService.java
+++ b/studymanager-observation/src/main/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyRequestService.java
@@ -214,7 +214,7 @@ public class LimeSurveyRequestService {
                 studyId, observationId);
     }
 
-    protected List<ParticipantData> activateParticipants(Set<Integer> participantIds, String surveyId) {
+    protected List<ParticipantData> activateParticipants(Set<ParticipantData.ParticipantInfo> participantIds, String surveyId) {
         String sessionKey = getSessionKey();
         createParticipantTable(surveyId, sessionKey);
         return createParticipants(participantIds, surveyId, sessionKey);
@@ -262,15 +262,15 @@ public class LimeSurveyRequestService {
     /**
      * This method sets both firstname and lastname of lime-participants as the id of more-participants
      */
-    private List<ParticipantData> createParticipants(Set<Integer> participantIds, String surveyId, String sessionKey) {
+    private List<ParticipantData> createParticipants(Set<ParticipantData.ParticipantInfo> participantIds, String surveyId, String sessionKey) {
         if (participantIds.isEmpty()) {
             return Collections.emptyList();
         }
         try {
             var participants = participantIds
                     .stream()
-                    .map(i ->
-                            new ParticipantCreationData(i.toString(), i.toString(), null)
+                    .map(parInfo ->
+                            new ParticipantCreationData(parInfo.firstname(), parInfo.lastname(), null)
                     )
                     .toList();
             HttpRequest request = createHttpRequest(

--- a/studymanager-observation/src/test/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyObservationTest.java
+++ b/studymanager-observation/src/test/java/io/redlink/more/studymanager/component/observation/lime/LimeSurveyObservationTest.java
@@ -2,6 +2,7 @@ package io.redlink.more.studymanager.component.observation.lime;
 
 import io.redlink.more.studymanager.component.observation.QuestionObservation;
 import io.redlink.more.studymanager.component.observation.QuestionObservationFactory;
+import io.redlink.more.studymanager.component.observation.lime.model.ParticipantData;
 import io.redlink.more.studymanager.core.datavalidity.DateMeasurementSummary;
 import io.redlink.more.studymanager.core.datavalidity.FieldValue;
 import io.redlink.more.studymanager.core.datavalidity.MeasurementSummary;
@@ -12,16 +13,25 @@ import io.redlink.more.studymanager.core.datavalidity.StringMeasurementSummary;
 import io.redlink.more.studymanager.core.measurement.Measurement;
 import io.redlink.more.studymanager.core.properties.ObservationProperties;
 import io.redlink.more.studymanager.core.sdk.MoreObservationSDK;
+import io.redlink.more.studymanager.core.sdk.MorePlatformSDK;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.AbstractMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -39,6 +49,99 @@ public class LimeSurveyObservationTest {
         Assertions.assertEquals("valid", o.checkAndGetSurveyId().get());
         Assertions.assertEquals("equals", o.checkAndGetSurveyId().get());
     }
+
+    @Test
+    public void testActivation() {
+        MoreObservationSDK sdk = mock(MoreObservationSDK.class);
+        LimeSurveyRequestService limeSurveyRequestService = mock(LimeSurveyRequestService.class);
+        ObservationProperties properties = new ObservationProperties();
+
+        long studyId = 42L;
+        int observationId = 123;
+
+        String limeSurveyId = "lime-id-1";
+        Set<Integer> studyParticipantIds = Set.of(1, 2, 3, 4, 5, 6);
+        properties.put("limeSurveyId", limeSurveyId);
+
+        LimeSurveyObservation questionObservation = new LimeSurveyObservation(sdk, properties, limeSurveyRequestService);
+
+        Mockito.when(sdk.getStudyId()).thenReturn(studyId);
+        Mockito.when(sdk.getObservationId()).thenReturn(observationId);
+        Mockito.when(sdk.participantIds(eq(MorePlatformSDK.ParticipantFilter.ALL)))
+                .thenReturn(studyParticipantIds);
+        Mockito.when(sdk.getValue(eq("limeSurveyId"), eq(String.class)))
+                .thenReturn(null);
+        Mockito.when(limeSurveyRequestService.listParticipants(eq(limeSurveyId), eq(0), eq(1000)))
+                .thenReturn(List.of(
+                        new ParticipantData( //old format
+                                new ParticipantData.ParticipantInfo("1", "1", null),
+                                "token-1",
+                                1),
+                        new ParticipantData( //old format
+                                new ParticipantData.ParticipantInfo("2", "2", null),
+                                "token-2",
+                                2),
+                        new ParticipantData( //new format other study
+                                new ParticipantData.ParticipantInfo("study_4-observation_4-participant_3", "more", null),
+                                "token-other-study",
+                                -1),
+                        new ParticipantData( //new format same study other observation
+                                new ParticipantData.ParticipantInfo("study_42-observation_4-participant_4", "more", null),
+                                "token-other-observation",
+                                -2),
+                        new ParticipantData( //participant 3 of the actual study
+                                new ParticipantData.ParticipantInfo("study_42-observation_123-participant_3", "more", null),
+                                "token-3",
+                                3),
+                        new ParticipantData( //participant 4
+                                new ParticipantData.ParticipantInfo("study_42-observation_123-participant_4", "more", null),
+                                "token-4",
+                                4),
+                        new ParticipantData( //not existing participant to validate deletion
+                                new ParticipantData.ParticipantInfo("study_42-observation_123-participant_99", "more", null),
+                                "token-99",
+                                99)
+                ));
+        Mockito.doNothing().when(limeSurveyRequestService).deleteParticipants(eq(limeSurveyId), eq(Set.of(99)));
+
+        Mockito.when(limeSurveyRequestService.activateParticipants(ArgumentMatchers.anySet(),eq(limeSurveyId)))
+                .thenAnswer( input -> {
+                    int initialValue = 5;
+                    AtomicInteger i = new AtomicInteger(initialValue);
+                    var pd = ((Set<ParticipantData.ParticipantInfo>)input.getArguments()[0])
+                            .stream()
+                            .map(pi -> {
+                                Assertions.assertNotNull(pi);
+                                Assertions.assertEquals("more", pi.lastname());
+                                Assertions.assertTrue(pi.firstname().startsWith("study_42-observation_123-participant_"));
+                                Integer pid = Integer.parseInt(pi.firstname().substring(pi.firstname().lastIndexOf('_')+1));
+                                return new AbstractMap.SimpleEntry<>(pid, pi);
+                            })
+                            .map(entry -> new ParticipantData(
+                                entry.getValue(),
+                                "token-" + entry.getKey(),
+                                entry.getKey()))
+                            .toList();
+                    Assertions.assertEquals(2, pd.size());
+                    return pd;
+                });
+
+        Mockito.doNothing().when(limeSurveyRequestService).setSurveyEndUrl(eq(limeSurveyId), eq(studyId), eq(observationId));
+        Mockito.doNothing().when(limeSurveyRequestService).activateSurvey(eq(limeSurveyId));
+
+        Mockito.doNothing().when(sdk).mergePropertiesForParticipant(any(Integer.class),any(ObservationProperties.class));
+
+        Mockito.when(limeSurveyRequestService.getBaseUrl()).thenReturn("http://example.com/lime-base-url");
+
+        questionObservation.activate();
+
+        Mockito.verify(limeSurveyRequestService, Mockito.times(1)).deleteParticipants(eq(limeSurveyId), eq(Set.of(99)));
+        Mockito.verify(limeSurveyRequestService, Mockito.times(1)).setSurveyEndUrl(eq(limeSurveyId), eq(studyId), eq(observationId));
+        Mockito.verify(limeSurveyRequestService, Mockito.times(1)).activateSurvey(eq(limeSurveyId));
+        //called once for every participant
+        Mockito.verify(sdk, Mockito.times(studyParticipantIds.size())).mergePropertiesForParticipant(any(Integer.class),any(ObservationProperties.class));
+    }
+
 
     @Test
     public void testValidation() {

--- a/studymanager-services/src/test/java/io/redlink/more/studymanager/repository/OccurredObservationRepositoryTest.java
+++ b/studymanager-services/src/test/java/io/redlink/more/studymanager/repository/OccurredObservationRepositoryTest.java
@@ -120,7 +120,21 @@ class OccurredObservationRepositoryTest {
         assertThat(occurredObservationResponse.created()).isAfter(startTime);
         assertThat(occurredObservationResponse.modified()).isEqualTo(occurredObservationResponse.created());
 
+        var ooGetById = occurredObservationRepository.getByIds(studyId, participant.getParticipantId(), observation.getObservationId(), startTime);
+        assertThat(ooGetById).isNotNull();
+        assertThat(ooGetById.studyId()).isEqualTo(studyId);
+        assertThat(ooGetById.participantId()).isEqualTo(participant.getParticipantId());
+        assertThat(ooGetById.observationId()).isEqualTo(observation.getObservationId());
+        assertThat(ooGetById.start()).isEqualTo(startTime);
 
+        var getByIdNotFound1 = occurredObservationRepository.getByIds(999, participant.getParticipantId(), observation.getObservationId(), startTime);
+        assertThat(getByIdNotFound1).isNull();
+        var getByIdNotFound2 = occurredObservationRepository.getByIds(studyId, 999, observation.getObservationId(), startTime);
+        assertThat(getByIdNotFound2).isNull();
+        var getByIdNotFound3 = occurredObservationRepository.getByIds(studyId, participant.getParticipantId(), 999, startTime);
+        assertThat(getByIdNotFound3).isNull();
+        var getByIdNotFound4 = occurredObservationRepository.getByIds(studyId, participant.getParticipantId(), observation.getObservationId(), startTime.plusSeconds(1));
+        assertThat(getByIdNotFound4).isNull();
 
         var updatedOccurentObservation = new OccurredObservation(
                 occurredObservationResponse.studyId(),


### PR DESCRIPTION
This adds support to use a single LimeSurvey for multiple studies and observations. It encodes the study, observation and participant in the givenname and adds more as lastname. It keeps backward compatibility for old/current studies by accepting the old format where the participantId was added as given and last name. It adds a UnitTest for the activate Method that checks if it performs the expected calls to the LimeServer and the SDK